### PR TITLE
Make TUI default entrypoint for agentvault

### DIFF
--- a/.github/actions/check-release-tag/action.yml
+++ b/.github/actions/check-release-tag/action.yml
@@ -16,10 +16,12 @@ inputs:
 outputs:
   version:
     description: Parsed version from release branch
+    value: ${{ steps.set-version.outputs.version }}
 runs:
   using: composite
   steps:
     - shell: bash
+      id: set-version
       run: |
         set -euo pipefail
         ROOT_DIR="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)"

--- a/.github/actions/check-release-tag/action.yml
+++ b/.github/actions/check-release-tag/action.yml
@@ -1,0 +1,40 @@
+name: check-release-tag
+description: Fail if a release/X.Y.Z branch already has a tag
+inputs:
+  release_branch:
+    description: Branch name to check (defaults to GITHUB_HEAD_REF/GITHUB_REF_NAME)
+    required: false
+    default: ""
+  repo_dir:
+    description: Path to the repo workspace
+    required: false
+    default: ""
+  fetch_tags:
+    description: Fetch tags before checking
+    required: false
+    default: "true"
+outputs:
+  version:
+    description: Parsed version from release branch
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        ROOT_DIR="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)"
+        repo_dir_input="${{ inputs.repo_dir }}"
+        if [[ -z "$repo_dir_input" ]]; then
+          repo_dir_input="${GITHUB_WORKSPACE:-$(pwd)}"
+        fi
+        args=("--repo" "$repo_dir_input")
+        if [[ -n "${{ inputs.release_branch }}" ]]; then
+          args+=("--branch" "${{ inputs.release_branch }}")
+        fi
+        if [[ "${{ inputs.fetch_tags }}" == "true" ]]; then
+          args+=("--fetch-tags")
+        fi
+        version="$(bash "$ROOT_DIR/scripts/check_release_tag.sh" "${args[@]}" --print-version)"
+        if [[ -n "$version" ]]; then
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Backward-compatible vault format
 
 ### Changed
+- `agentvault` with no command now launches the interactive TUI by default, while explicit CLI commands/subcommands continue to behave the same.
 - TUI view modes renamed for clarity (viewAgentList, viewAgentDetail, etc.)
 - Export/import now includes provider configurations
 - Improved error messages and user feedback

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Detailed command and TUI references: `docs/README.md`.
 # 1. Initialize vault with master password
 agentvault init
 
-# 2. Launch TUI (detected installed agents are auto-added)
-agentvault -t
+# 2. Launch TUI (default when no command is provided)
+agentvault
 
 # 3. Initialize default rules and roles (one time)
 agentvault rules init
@@ -37,12 +37,12 @@ agentvault session create my-project --dir /path/to/project
 agentvault session start my-project
 
 # 6. Launch TUI to manage everything
-agentvault -t
+agentvault
 ```
 
 ## TUI First-Time Flow (Simplified)
 
-1. Open `agentvault -t`.
+1. Open `agentvault`.
 2. Go to `Detected` tab:
    - installed agents are auto-added to vault
    - press `Enter` for details
@@ -83,7 +83,7 @@ brew install nikolareljin/tap/agentvault
 | `detect add` | Auto-add detected agents |
 | `prompt <name>` | Route prompts through AgentVault gateway with usage logging |
 | `status` | Show token usage and quota status (JSON for orchestration) |
-| `--tui`, `-t` | Launch interactive terminal UI |
+| `--tui`, `-t` | Launch interactive terminal UI (same as default `agentvault`) |
 
 ### Agent Management
 | Command | Description |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,8 +64,11 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
-func shouldLaunchTUI(launchTUI bool, args []string) bool {
-	return launchTUI || len(args) == 0
+func shouldLaunchTUI(flagProvided bool, launchTUI bool, args []string) bool {
+	if flagProvided {
+		return launchTUI
+	}
+	return len(args) == 0
 }
 
 func init() {
@@ -73,7 +76,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		launchTUI, _ := cmd.Flags().GetBool("tui")
-		if shouldLaunchTUI(launchTUI, args) {
+		flagProvided := cmd.Flags().Changed("tui")
+		if shouldLaunchTUI(flagProvided, launchTUI, args) {
 			v, err := openVault()
 			if err != nil {
 				return tui.Run()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func shouldLaunchTUI(flagProvided bool, launchTUI bool, args []string) bool {
 
 func init() {
 	rootCmd.PersistentFlags().String("config", "", "config directory (default: ~/.config/agentvault)")
-	rootCmd.PersistentFlags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
+	rootCmd.Flags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		launchTUI, _ := cmd.Flags().GetBool("tui")
 		flagProvided := cmd.Flags().Changed("tui")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func shouldLaunchTUI(flagProvided bool, launchTUI bool, args []string) bool {
 
 func init() {
 	rootCmd.PersistentFlags().String("config", "", "config directory (default: ~/.config/agentvault)")
-	rootCmd.Flags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
+	rootCmd.PersistentFlags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		launchTUI, _ := cmd.Flags().GetBool("tui")
 		flagProvided := cmd.Flags().Changed("tui")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ Get started:
   agentvault init              # Create vault
   agentvault detect add        # Auto-detect and add agents
   agentvault rules init        # Set up default rules
-  agentvault -t                # Launch interactive UI`,
+  agentvault                   # Launch interactive UI (default)`,
 }
 
 // Execute runs the root command. Called from main().
@@ -64,12 +64,16 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+func shouldLaunchTUI(launchTUI bool, args []string) bool {
+	return launchTUI || len(args) == 0
+}
+
 func init() {
 	rootCmd.PersistentFlags().String("config", "", "config directory (default: ~/.config/agentvault)")
-	rootCmd.PersistentFlags().BoolP("tui", "t", false, "launch interactive terminal UI")
+	rootCmd.PersistentFlags().BoolP("tui", "t", false, "launch interactive terminal UI (default when no command is provided)")
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		launchTUI, _ := cmd.Flags().GetBool("tui")
-		if launchTUI {
+		if shouldLaunchTUI(launchTUI, args) {
 			v, err := openVault()
 			if err != nil {
 				return tui.Run()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "testing"
+
+func TestShouldLaunchTUI_DefaultNoArgs(t *testing.T) {
+	if !shouldLaunchTUI(false, nil) {
+		t.Fatalf("shouldLaunchTUI(false, nil) = false, want true")
+	}
+}
+
+func TestShouldLaunchTUI_WithExplicitFlag(t *testing.T) {
+	if !shouldLaunchTUI(true, []string{"ignored"}) {
+		t.Fatalf("shouldLaunchTUI(true, args) = false, want true")
+	}
+}
+
+func TestShouldLaunchTUI_WithArgsAndNoFlag(t *testing.T) {
+	if shouldLaunchTUI(false, []string{"list"}) {
+		t.Fatalf("shouldLaunchTUI(false, args) = true, want false")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,19 +3,25 @@ package cmd
 import "testing"
 
 func TestShouldLaunchTUI_DefaultNoArgs(t *testing.T) {
-	if !shouldLaunchTUI(false, nil) {
-		t.Fatalf("shouldLaunchTUI(false, nil) = false, want true")
+	if !shouldLaunchTUI(false, false, nil) {
+		t.Fatalf("shouldLaunchTUI(false, false, nil) = false, want true")
 	}
 }
 
 func TestShouldLaunchTUI_WithExplicitFlag(t *testing.T) {
-	if !shouldLaunchTUI(true, []string{"ignored"}) {
-		t.Fatalf("shouldLaunchTUI(true, args) = false, want true")
+	if !shouldLaunchTUI(true, true, []string{"ignored"}) {
+		t.Fatalf("shouldLaunchTUI(true, true, args) = false, want true")
 	}
 }
 
 func TestShouldLaunchTUI_WithArgsAndNoFlag(t *testing.T) {
-	if shouldLaunchTUI(false, []string{"list"}) {
-		t.Fatalf("shouldLaunchTUI(false, args) = true, want false")
+	if shouldLaunchTUI(false, false, []string{"list"}) {
+		t.Fatalf("shouldLaunchTUI(false, false, args) = true, want false")
+	}
+}
+
+func TestShouldLaunchTUI_ExplicitFalseDisablesDefault(t *testing.T) {
+	if shouldLaunchTUI(true, false, nil) {
+		t.Fatalf("shouldLaunchTUI(true, false, nil) = true, want false")
 	}
 }

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -415,8 +415,10 @@ Flags:
 Launch:
 
 ```bash
+agentvault
+# optional explicit flag:
 agentvault --tui
-# or
+# or short:
 agentvault -t
 ```
 
@@ -539,7 +541,7 @@ Search mode (Agents tab):
 ## 5.1 Daily startup
 
 ```bash
-agentvault -t
+agentvault
 ```
 
 Use Commands tab + `g` for prompt gateway workflow.

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -7,13 +7,13 @@ Related docs: [Docs Index](./README.md) | [CLI Reference](./cli-reference.md) | 
 ## 1. Global CLI Usage
 
 ```bash
-agentvault [global flags] <command> [subcommand] [args] [flags]
+agentvault [global flags] [command] [subcommand] [args] [flags]
 ```
 
 ### Global flags
 
 - `--config <dir>`: Use custom config directory instead of default `~/.config/agentvault`.
-- `-t, --tui`: Launch interactive TUI.
+- `-t, --tui`: Launch interactive TUI (also the default when no command is provided).
 
 ## 2. Top-Level Commands
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,13 +7,13 @@ Related docs: [Docs Index](./README.md) | [TUI Reference](./tui-reference.md) | 
 ## Global usage
 
 ```bash
-agentvault [global flags] <command> [subcommand] [args] [flags]
+agentvault [global flags] [command] [subcommand] [args] [flags]
 ```
 
 ## Global flags
 
 - `--config <dir>`: custom config dir, default `~/.config/agentvault`
-- `-t, --tui`: launch TUI
+- `-t, --tui`: launch TUI (also the default when no command is provided)
 
 ## Top-level commands
 

--- a/docs/tui-reference.md
+++ b/docs/tui-reference.md
@@ -5,6 +5,8 @@ Related docs: [Docs Index](./README.md) | [CLI Reference](./cli-reference.md) | 
 Launch TUI:
 
 ```bash
+agentvault
+# or
 agentvault --tui
 # or
 agentvault -t

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -5,7 +5,7 @@ Related docs: [Docs Index](./README.md) | [CLI Reference](./cli-reference.md) | 
 ## Daily workflow through TUI gateway
 
 ```bash
-agentvault -t
+agentvault
 ```
 
 Then:

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -75,7 +75,10 @@ fi
 version="${BASH_REMATCH[1]}"
 
 if $fetch_tags; then
-  git -C "$repo_dir" fetch --tags --prune --force >/dev/null 2>&1 || true
+  if ! git -C "$repo_dir" fetch --tags --prune --force >/dev/null 2>&1; then
+    log_error "Failed to fetch tags from repository at '$repo_dir'"
+    exit 1
+  fi
 fi
 
 if git -C "$repo_dir" show-ref --tags -q "refs/tags/$version"; then

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -91,7 +91,7 @@ fi
 
 if $fetch_tags; then
   fetch_args=(--tags --prune --force)
-  if git -C "$repo_dir" fetch -h 2>&1 | grep -q -- "--prune-tags"; then
+  if grep -q -- "--prune-tags" < <(git -C "$repo_dir" fetch -h 2>&1); then
     fetch_args+=(--prune-tags)
   fi
   if ! git -C "$repo_dir" fetch "${fetch_args[@]}" >/dev/null 2>&1; then

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -77,7 +77,7 @@ if [[ -z "$branch" ]]; then
   exit 2
 fi
 
-if [[ ! "$branch" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?)$ ]]; then
+if [[ ! "$branch" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?)$ ]]; then
   log_info "Skipping: '$branch' is not a release branch"
   exit 0
 fi

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -90,7 +90,11 @@ if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 if $fetch_tags; then
-  if ! git -C "$repo_dir" fetch --tags --prune --force >/dev/null 2>&1; then
+  fetch_args=(--tags --prune --force)
+  if git -C "$repo_dir" fetch -h 2>&1 | grep -q -- "--prune-tags"; then
+    fetch_args+=(--prune-tags)
+  fi
+  if ! git -C "$repo_dir" fetch "${fetch_args[@]}" >/dev/null 2>&1; then
     log_error "Failed to fetch tags from repository at '$repo_dir'"
     exit 1
   fi

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -31,11 +31,21 @@ print_version=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --branch)
-      branch="${2:-}"
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log_error "Missing value for --branch"
+        usage
+        exit 2
+      fi
+      branch="$2"
       shift 2
       ;;
     --repo)
-      repo_dir="${2:-}"
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log_error "Missing value for --repo"
+        usage
+        exit 2
+      fi
+      repo_dir="$2"
       shift 2
       ;;
     --fetch-tags)
@@ -73,6 +83,11 @@ if [[ ! "$branch" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?)$ ]]; the
 fi
 
 version="${BASH_REMATCH[1]}"
+
+if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log_error "Repository path '$repo_dir' is not a valid git worktree"
+  exit 1
+fi
 
 if $fetch_tags; then
   if ! git -C "$repo_dir" fetch --tags --prune --force >/dev/null 2>&1; then

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -100,7 +100,7 @@ if $fetch_tags; then
   fi
 fi
 
-if git -C "$repo_dir" show-ref --tags -q "refs/tags/$version"; then
+if git -C "$repo_dir" show-ref --verify --quiet "refs/tags/$version"; then
   log_error "Tag $version already exists for release branch $branch"
   exit 1
 fi

--- a/scripts/check_release_tag.sh
+++ b/scripts/check_release_tag.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Guard against release tag collisions for release/X.Y.Z[-rcN] branches.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: check_release_tag.sh [--branch <branch>] [--repo <path>] [--fetch-tags] [--print-version]
+
+Options:
+  --branch <branch>   Release branch name. Defaults to GITHUB_HEAD_REF/GITHUB_REF_NAME.
+  --repo <path>       Repository path. Defaults to GITHUB_WORKSPACE or current directory.
+  --fetch-tags        Fetch tags before checking.
+  --print-version     Print parsed release version when check passes.
+  -h, --help          Show help.
+USAGE
+}
+
+log_info() {
+  echo "[INFO] $*" >&2
+}
+
+log_error() {
+  echo "[ERROR] $*" >&2
+}
+
+branch=""
+repo_dir="${GITHUB_WORKSPACE:-$(pwd)}"
+fetch_tags=false
+print_version=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)
+      branch="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      repo_dir="${2:-}"
+      shift 2
+      ;;
+    --fetch-tags)
+      fetch_tags=true
+      shift
+      ;;
+    --print-version)
+      print_version=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$branch" ]]; then
+  branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+fi
+
+if [[ -z "$branch" ]]; then
+  log_error "Branch not provided and GITHUB_REF_NAME/GITHUB_HEAD_REF not set"
+  exit 2
+fi
+
+if [[ ! "$branch" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+(-rc\.?[0-9]+)?)$ ]]; then
+  log_info "Skipping: '$branch' is not a release branch"
+  exit 0
+fi
+
+version="${BASH_REMATCH[1]}"
+
+if $fetch_tags; then
+  git -C "$repo_dir" fetch --tags --prune --force >/dev/null 2>&1 || true
+fi
+
+if git -C "$repo_dir" show-ref --tags -q "refs/tags/$version"; then
+  log_error "Tag $version already exists for release branch $branch"
+  exit 1
+fi
+
+log_info "Tag $version is available for release branch $branch"
+if $print_version; then
+  echo "$version"
+fi


### PR DESCRIPTION
## Summary
- make `agentvault` launch the interactive TUI when no command is provided
- keep existing command/subcommand behavior unchanged
- update help/docs/changelog to clearly document default TUI behavior
- add unit tests for root command TUI-launch decision logic
- add local `check-release-tag` GitHub composite action and `scripts/check_release_tag.sh` used by release-tag gate workflows
- harden release-tag script behavior to fail when tag fetch fails instead of silently continuing

## Validation
- `go test ./...`
- `./scripts/check_release_tag.sh --branch release/0.2.0 --repo . --print-version`

Closes #1
