### PR TITLE
fix: prefer local vault prompt settings over environment fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
 ### Fixed
 - Code formatting issues resolved with gofmt
 - Test files updated for new view mode names
+- Prompt runtime configuration precedence now consistently prefers local vault values over environment variables, with environment and default fallbacks applied explicitly.
+- TUI agent detail now shows effective value sources (`local`, `env`, `default`) for prompt-related model/API key/base URL fields.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ agentvault prompt my-ollama --text "summarize this design" --json
 agentvault -p
 ```
 
+Runtime value precedence for prompt execution is:
+- local agent setting in vault
+- process environment fallback (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OLLAMA_HOST`)
+- built-in default fallback (for Ollama base URL: `http://localhost:11434`)
+
+In the TUI Agent detail view, effective values include source tags (`local`, `env`, `default`) for model/API key/base URL.
+
 By default, prompt runs are written in plaintext to `~/.config/agentvault/prompt-history.jsonl`, which may contain sensitive data.
 Treat this file as sensitive and disable or clear it when prompts may include secrets.
 Prompt mode can also store session transcript metadata in encrypted vault state on exit.

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/nikolareljin/agentvault/internal/agent"
+	"github.com/nikolareljin/agentvault/internal/envutil"
 	"github.com/nikolareljin/agentvault/internal/textutil"
 	"github.com/spf13/cobra"
 )
@@ -331,7 +332,7 @@ func executeCodexPrompt(a agent.Agent, prompt string, timeout time.Duration) (pr
 	defer cancel()
 
 	cmd := exec.CommandContext(runCtx, "codex", args...)
-	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
+	cmd.Env = envutil.SetValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -418,7 +419,7 @@ func executeClaudePrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	defer cancel()
 
 	cmd := exec.CommandContext(runCtx, "claude", args...)
-	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
+	cmd.Env = envutil.SetValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -457,21 +458,6 @@ func executeClaudePrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	}
 
 	return promptResult{Response: strings.TrimSpace(response), Usage: usage}, nil
-}
-
-func setEnvValueWithPrecedence(baseEnv []string, key string, value string) []string {
-	prefix := key + "="
-	out := make([]string, 0, len(baseEnv)+1)
-	for _, entry := range baseEnv {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		out = append(out, entry)
-	}
-	if value != "" {
-		out = append(out, prefix+value)
-	}
-	return out
 }
 
 func appendPromptRecord(path string, rec PromptRecord) error {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -89,6 +89,10 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("agent %q not found", args[0])
 	}
+	runtimeCfg := agent.ResolvePromptRuntimeConfig(a)
+	a.Model = runtimeCfg.Model.Value
+	a.APIKey = runtimeCfg.APIKey.Value
+	a.BaseURL = runtimeCfg.BaseURL.Value
 
 	text, err := readPromptInput(cmd)
 	if err != nil {
@@ -123,6 +127,11 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 				"optimized":        optimized,
 				"profile":          optimizationProfile,
 				"effective_prompt": effectivePrompt,
+				"value_sources": map[string]string{
+					"model":    string(runtimeCfg.Model.Source),
+					"api_key":  string(runtimeCfg.APIKey.Source),
+					"base_url": string(runtimeCfg.BaseURL.Source),
+				},
 			})
 			return nil
 		}
@@ -322,10 +331,7 @@ func executeCodexPrompt(a agent.Agent, prompt string, timeout time.Duration) (pr
 	defer cancel()
 
 	cmd := exec.CommandContext(runCtx, "codex", args...)
-	cmd.Env = os.Environ()
-	if strings.TrimSpace(a.APIKey) != "" {
-		cmd.Env = append(cmd.Env, "OPENAI_API_KEY="+a.APIKey)
-	}
+	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -412,10 +418,7 @@ func executeClaudePrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	defer cancel()
 
 	cmd := exec.CommandContext(runCtx, "claude", args...)
-	cmd.Env = os.Environ()
-	if strings.TrimSpace(a.APIKey) != "" {
-		cmd.Env = append(cmd.Env, "ANTHROPIC_API_KEY="+a.APIKey)
-	}
+	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -454,6 +457,21 @@ func executeClaudePrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	}
 
 	return promptResult{Response: strings.TrimSpace(response), Usage: usage}, nil
+}
+
+func setEnvValueWithPrecedence(baseEnv []string, key string, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(baseEnv)+1)
+	for _, entry := range baseEnv {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if value != "" {
+		out = append(out, prefix+value)
+	}
+	return out
 }
 
 func appendPromptRecord(path string, rec PromptRecord) error {

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -147,6 +147,13 @@ Flags:
 - `--history-file <path>`: Override default `~/.config/agentvault/prompt-history.jsonl`.
 - `--timeout <duration>` (default: `5m`): Provider call timeout.
 
+Runtime value precedence:
+- local agent value in vault
+- environment fallback (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OLLAMA_HOST`)
+- default fallback (`http://localhost:11434` for Ollama base URL)
+
+TUI agent detail renders effective model/API key/base URL with source tags (`local`, `env`, `default`).
+
 Examples:
 ```bash
 # list configured agents and pick one name

--- a/internal/agent/runtime_config.go
+++ b/internal/agent/runtime_config.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"os"
+	"strings"
+)
+
+// ValueSource indicates where an effective runtime value came from.
+type ValueSource string
+
+const (
+	ValueSourceLocal   ValueSource = "local"
+	ValueSourceEnv     ValueSource = "env"
+	ValueSourceDefault ValueSource = "default"
+	ValueSourceUnset   ValueSource = "unset"
+)
+
+// ResolvedValue contains an effective value plus its source.
+type ResolvedValue struct {
+	Value  string
+	Source ValueSource
+}
+
+// PromptRuntimeConfig captures effective prompt-runtime values with precedence metadata.
+type PromptRuntimeConfig struct {
+	Model   ResolvedValue
+	APIKey  ResolvedValue
+	BaseURL ResolvedValue
+}
+
+// ResolvePromptRuntimeConfig resolves runtime values with precedence:
+// local agent settings > process environment > built-in defaults.
+func ResolvePromptRuntimeConfig(a Agent) PromptRuntimeConfig {
+	cfg := PromptRuntimeConfig{
+		Model: resolveValue(strings.TrimSpace(a.Model), nil, ""),
+	}
+
+	switch a.Provider {
+	case ProviderClaude:
+		cfg.APIKey = resolveValue(strings.TrimSpace(a.APIKey), []string{"ANTHROPIC_API_KEY"}, "")
+		cfg.BaseURL = resolveValue(strings.TrimSpace(a.BaseURL), nil, "")
+	case ProviderCodex, ProviderOpenAI:
+		cfg.APIKey = resolveValue(strings.TrimSpace(a.APIKey), []string{"OPENAI_API_KEY"}, "")
+		cfg.BaseURL = resolveValue(strings.TrimSpace(a.BaseURL), nil, "")
+	case ProviderOllama:
+		cfg.APIKey = resolveValue(strings.TrimSpace(a.APIKey), nil, "")
+		cfg.BaseURL = resolveValue(strings.TrimSpace(a.BaseURL), []string{"OLLAMA_HOST"}, "http://localhost:11434")
+	default:
+		cfg.APIKey = resolveValue(strings.TrimSpace(a.APIKey), nil, "")
+		cfg.BaseURL = resolveValue(strings.TrimSpace(a.BaseURL), nil, "")
+	}
+
+	return cfg
+}
+
+func resolveValue(local string, envKeys []string, defaultValue string) ResolvedValue {
+	if local != "" {
+		return ResolvedValue{Value: local, Source: ValueSourceLocal}
+	}
+	for _, key := range envKeys {
+		if key == "" {
+			continue
+		}
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return ResolvedValue{Value: value, Source: ValueSourceEnv}
+		}
+	}
+	if defaultValue != "" {
+		return ResolvedValue{Value: defaultValue, Source: ValueSourceDefault}
+	}
+	return ResolvedValue{Source: ValueSourceUnset}
+}

--- a/internal/agent/runtime_config_test.go
+++ b/internal/agent/runtime_config_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import "testing"
+
+func TestResolvePromptRuntimeConfig_PrefersLocalOverEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "env-openai-key")
+	a := Agent{
+		Provider: ProviderCodex,
+		Model:    "gpt-5-codex",
+		APIKey:   "local-openai-key",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.APIKey.Value != "local-openai-key" {
+		t.Fatalf("api key = %q, want local value", cfg.APIKey.Value)
+	}
+	if cfg.APIKey.Source != ValueSourceLocal {
+		t.Fatalf("api key source = %q, want %q", cfg.APIKey.Source, ValueSourceLocal)
+	}
+}
+
+func TestResolvePromptRuntimeConfig_UsesEnvFallback(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "env-anthropic-key")
+	a := Agent{
+		Provider: ProviderClaude,
+		Model:    "claude-sonnet",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.APIKey.Value != "env-anthropic-key" {
+		t.Fatalf("api key = %q, want env value", cfg.APIKey.Value)
+	}
+	if cfg.APIKey.Source != ValueSourceEnv {
+		t.Fatalf("api key source = %q, want %q", cfg.APIKey.Source, ValueSourceEnv)
+	}
+}
+
+func TestResolvePromptRuntimeConfig_UsesDefaultFallback(t *testing.T) {
+	a := Agent{
+		Provider: ProviderOllama,
+		Model:    "llama3.2",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.BaseURL.Value != "http://localhost:11434" {
+		t.Fatalf("base url = %q, want default", cfg.BaseURL.Value)
+	}
+	if cfg.BaseURL.Source != ValueSourceDefault {
+		t.Fatalf("base url source = %q, want %q", cfg.BaseURL.Source, ValueSourceDefault)
+	}
+}
+
+func TestResolvePromptRuntimeConfig_UsesEnvForOllamaBaseURL(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://env-ollama:11434")
+	a := Agent{
+		Provider: ProviderOllama,
+		Model:    "llama3.2",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.BaseURL.Value != "http://env-ollama:11434" {
+		t.Fatalf("base url = %q, want env value", cfg.BaseURL.Value)
+	}
+	if cfg.BaseURL.Source != ValueSourceEnv {
+		t.Fatalf("base url source = %q, want %q", cfg.BaseURL.Source, ValueSourceEnv)
+	}
+}

--- a/internal/agent/runtime_config_test.go
+++ b/internal/agent/runtime_config_test.go
@@ -36,6 +36,7 @@ func TestResolvePromptRuntimeConfig_UsesEnvFallback(t *testing.T) {
 }
 
 func TestResolvePromptRuntimeConfig_UsesDefaultFallback(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "")
 	a := Agent{
 		Provider: ProviderOllama,
 		Model:    "llama3.2",

--- a/internal/agent/runtime_config_test.go
+++ b/internal/agent/runtime_config_test.go
@@ -66,3 +66,37 @@ func TestResolvePromptRuntimeConfig_UsesEnvForOllamaBaseURL(t *testing.T) {
 		t.Fatalf("base url source = %q, want %q", cfg.BaseURL.Source, ValueSourceEnv)
 	}
 }
+
+func TestResolvePromptRuntimeConfig_PrefersLocalOllamaBaseURLOverEnv(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://env-ollama:11434")
+	a := Agent{
+		Provider: ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  "http://local-ollama:11434",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.BaseURL.Value != "http://local-ollama:11434" {
+		t.Fatalf("base url = %q, want local value", cfg.BaseURL.Value)
+	}
+	if cfg.BaseURL.Source != ValueSourceLocal {
+		t.Fatalf("base url source = %q, want %q", cfg.BaseURL.Source, ValueSourceLocal)
+	}
+}
+
+func TestResolvePromptRuntimeConfig_PrefersLocalClaudeAPIKeyOverEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "env-anthropic-key")
+	a := Agent{
+		Provider: ProviderClaude,
+		Model:    "claude-sonnet",
+		APIKey:   "local-anthropic-key",
+	}
+
+	cfg := ResolvePromptRuntimeConfig(a)
+	if cfg.APIKey.Value != "local-anthropic-key" {
+		t.Fatalf("api key = %q, want local value", cfg.APIKey.Value)
+	}
+	if cfg.APIKey.Source != ValueSourceLocal {
+		t.Fatalf("api key source = %q, want %q", cfg.APIKey.Source, ValueSourceLocal)
+	}
+}

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -1,0 +1,38 @@
+package envutil
+
+import (
+	"runtime"
+	"strings"
+)
+
+// SetValueWithPrecedence returns environment entries where key is removed from
+// baseEnv and then re-appended with value (if value is non-empty).
+func SetValueWithPrecedence(baseEnv []string, key string, value string) []string {
+	out := make([]string, 0, len(baseEnv)+1)
+	for _, entry := range baseEnv {
+		entryKey, _, hasEquals := strings.Cut(entry, "=")
+		if !hasEquals {
+			out = append(out, entry)
+			continue
+		}
+		if envKeyEquals(entryKey, key) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if value != "" {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func envKeyEquals(left, right string) bool {
+	return envKeyEqualsForOS(runtime.GOOS, left, right)
+}
+
+func envKeyEqualsForOS(goos, left, right string) bool {
+	if goos == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -1,0 +1,51 @@
+package envutil
+
+import "testing"
+
+func TestSetValueWithPrecedence_ReplacesExistingKey(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"OPENAI_API_KEY=old",
+		"HOME=/tmp/home",
+	}
+	got := SetValueWithPrecedence(base, "OPENAI_API_KEY", "new")
+
+	var (
+		count int
+		value string
+	)
+	for _, entry := range got {
+		if len(entry) >= len("OPENAI_API_KEY=") && entry[:len("OPENAI_API_KEY=")] == "OPENAI_API_KEY=" {
+			count++
+			value = entry[len("OPENAI_API_KEY="):]
+		}
+	}
+	if count != 1 {
+		t.Fatalf("OPENAI_API_KEY entries = %d, want 1 (%v)", count, got)
+	}
+	if value != "new" {
+		t.Fatalf("OPENAI_API_KEY value = %q, want %q", value, "new")
+	}
+}
+
+func TestSetValueWithPrecedence_RemovesKeyWhenValueEmpty(t *testing.T) {
+	base := []string{"A=1", "B=2"}
+	got := SetValueWithPrecedence(base, "B", "")
+	for _, entry := range got {
+		if entry == "B=2" || entry == "B=" {
+			t.Fatalf("unexpected B entry after removal: %v", got)
+		}
+	}
+}
+
+func TestEnvKeyEqualsForOS_WindowsIsCaseInsensitive(t *testing.T) {
+	if !envKeyEqualsForOS("windows", "OpenAI_Api_Key", "OPENAI_API_KEY") {
+		t.Fatal("expected case-insensitive match for windows")
+	}
+}
+
+func TestEnvKeyEqualsForOS_LinuxIsCaseSensitive(t *testing.T) {
+	if envKeyEqualsForOS("linux", "OpenAI_Api_Key", "OPENAI_API_KEY") {
+		t.Fatal("expected case-sensitive mismatch for linux")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,6 +38,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/nikolareljin/agentvault/internal/agent"
+	"github.com/nikolareljin/agentvault/internal/envutil"
 	statuspkg "github.com/nikolareljin/agentvault/internal/status"
 	"github.com/nikolareljin/agentvault/internal/vault"
 )
@@ -2415,7 +2416,7 @@ func executeGatewayCodex(a agent.Agent, prompt string, timeout time.Duration) (s
 	args = append(args, prompt)
 
 	cmd := exec.Command("codex", args...)
-	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
+	cmd.Env = envutil.SetValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -2445,7 +2446,7 @@ func executeGatewayClaude(a agent.Agent, prompt string, timeout time.Duration) (
 	args = append(args, prompt)
 
 	cmd := exec.Command("claude", args...)
-	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
+	cmd.Env = envutil.SetValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -2494,21 +2495,6 @@ func runCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
 		}
 		return fmt.Errorf("timed out after %s", timeout)
 	}
-}
-
-func setEnvValueWithPrecedence(baseEnv []string, key string, value string) []string {
-	prefix := key + "="
-	out := make([]string, 0, len(baseEnv)+1)
-	for _, entry := range baseEnv {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		out = append(out, entry)
-	}
-	if value != "" {
-		out = append(out, prefix+value)
-	}
-	return out
 }
 
 func parseGatewayCodexUsage(raw string) gatewayUsage {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1461,6 +1461,7 @@ func (m model) renderAgentDetail() string {
 		return ""
 	}
 	a := m.agents[m.filteredAgents[m.cursor]]
+	runtimeCfg := agent.ResolvePromptRuntimeConfig(a)
 	var b strings.Builder
 
 	b.WriteString(titleStyle.Render(fmt.Sprintf("Agent: %s", a.Name)))
@@ -1473,17 +1474,25 @@ func (m model) renderAgentDetail() string {
 		b.WriteString(fmt.Sprintf("  %s  %s\n", labelStyle.Render(fmt.Sprintf("%-16s", label+":")), value))
 	}
 
-	field("Provider", string(a.Provider))
-	field("Model", a.Model)
+	sourceSuffix := func(source agent.ValueSource) string {
+		if source == agent.ValueSourceUnset {
+			return ""
+		}
+		return fmt.Sprintf(" (%s)", source)
+	}
 
-	if a.APIKey != "" {
-		masked := a.APIKey[:min(4, len(a.APIKey))] + strings.Repeat("*", max(0, len(a.APIKey)-4))
-		field("API Key", masked)
+	field("Provider", string(a.Provider))
+	field("Model", runtimeCfg.Model.Value+sourceSuffix(runtimeCfg.Model.Source))
+
+	if runtimeCfg.APIKey.Value != "" {
+		masked := runtimeCfg.APIKey.Value[:min(4, len(runtimeCfg.APIKey.Value))] +
+			strings.Repeat("*", max(0, len(runtimeCfg.APIKey.Value)-4))
+		field("API Key", masked+sourceSuffix(runtimeCfg.APIKey.Source))
 	} else {
 		field("API Key", "")
 	}
 
-	field("Base URL", a.BaseURL)
+	field("Base URL", runtimeCfg.BaseURL.Value+sourceSuffix(runtimeCfg.BaseURL.Source))
 	field("Role", a.Role)
 
 	effectivePrompt := a.EffectiveSystemPrompt(m.shared)
@@ -2311,6 +2320,11 @@ func runGatewayPromptCmd(a agent.Agent, prompt string, timeout time.Duration) te
 }
 
 func executeGatewayPrompt(a agent.Agent, prompt string, timeout time.Duration) (string, gatewayUsage, error) {
+	runtimeCfg := agent.ResolvePromptRuntimeConfig(a)
+	a.Model = runtimeCfg.Model.Value
+	a.APIKey = runtimeCfg.APIKey.Value
+	a.BaseURL = runtimeCfg.BaseURL.Value
+
 	switch a.Provider {
 	case agent.ProviderOllama:
 		return executeGatewayOllama(a, prompt, timeout)
@@ -2401,10 +2415,7 @@ func executeGatewayCodex(a agent.Agent, prompt string, timeout time.Duration) (s
 	args = append(args, prompt)
 
 	cmd := exec.Command("codex", args...)
-	cmd.Env = os.Environ()
-	if strings.TrimSpace(a.APIKey) != "" {
-		cmd.Env = append(cmd.Env, "OPENAI_API_KEY="+a.APIKey)
-	}
+	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "OPENAI_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -2434,10 +2445,7 @@ func executeGatewayClaude(a agent.Agent, prompt string, timeout time.Duration) (
 	args = append(args, prompt)
 
 	cmd := exec.Command("claude", args...)
-	cmd.Env = os.Environ()
-	if strings.TrimSpace(a.APIKey) != "" {
-		cmd.Env = append(cmd.Env, "ANTHROPIC_API_KEY="+a.APIKey)
-	}
+	cmd.Env = setEnvValueWithPrecedence(os.Environ(), "ANTHROPIC_API_KEY", strings.TrimSpace(a.APIKey))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -2486,6 +2494,21 @@ func runCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
 		}
 		return fmt.Errorf("timed out after %s", timeout)
 	}
+}
+
+func setEnvValueWithPrecedence(baseEnv []string, key string, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(baseEnv)+1)
+	for _, entry := range baseEnv {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if value != "" {
+		out = append(out, prefix+value)
+	}
+	return out
 }
 
 func parseGatewayCodexUsage(raw string) gatewayUsage {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -99,6 +99,30 @@ func TestEnterDetailView(t *testing.T) {
 	if !strings.Contains(view, "sk-1") {
 		t.Error("detailView missing masked API key prefix")
 	}
+	if !strings.Contains(view, "(local)") {
+		t.Error("detailView should show value source tags")
+	}
+}
+
+func TestRenderAgentDetail_ShowsEnvAndDefaultSources(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://env-ollama:11434")
+	dir := t.TempDir()
+	v := vault.New(dir + "/env-default.enc")
+	if err := v.Init("testpass"); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	_ = v.Add(agent.Agent{Name: "ollama-env", Provider: agent.ProviderOllama, Model: "llama3"})
+	m := initialModel(v)
+	view := m.renderAgentDetail()
+	if !strings.Contains(view, "http://env-ollama:11434 (env)") {
+		t.Fatalf("expected env source in base URL, got: %s", view)
+	}
+
+	t.Setenv("OLLAMA_HOST", "")
+	view = m.renderAgentDetail()
+	if !strings.Contains(view, "http://localhost:11434 (default)") {
+		t.Fatalf("expected default source in base URL, got: %s", view)
+	}
 }
 
 func TestEscBackToList(t *testing.T) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -107,11 +108,13 @@ func TestEnterDetailView(t *testing.T) {
 func TestRenderAgentDetail_ShowsEnvAndDefaultSources(t *testing.T) {
 	t.Setenv("OLLAMA_HOST", "http://env-ollama:11434")
 	dir := t.TempDir()
-	v := vault.New(dir + "/env-default.enc")
+	v := vault.New(filepath.Join(dir, "env-default.enc"))
 	if err := v.Init("testpass"); err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
-	_ = v.Add(agent.Agent{Name: "ollama-env", Provider: agent.ProviderOllama, Model: "llama3"})
+	if err := v.Add(agent.Agent{Name: "ollama-env", Provider: agent.ProviderOllama, Model: "llama3"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
 	m := initialModel(v)
 	view := m.renderAgentDetail()
 	if !strings.Contains(view, "http://env-ollama:11434 (env)") {


### PR DESCRIPTION
## Summary
- enforce explicit prompt runtime precedence: local vault value > environment fallback > default fallback
- apply consistent runtime resolution in both `agentvault prompt` and TUI gateway execution paths
- sanitize command env injection so resolved values are deterministic and not accidentally overridden
- show effective source tags (`local`, `env`, `default`) in TUI Agent detail
- document precedence in README and detailed usage docs

## Validation
- go test ./...
 
Closes #9