### PR TITLE
feat: add portable workflow template management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ artifacts/
 go[1-9]*.*.gz
 
 /ignore/
+examples/
 TODO.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+- `templates` command group with `list`, `show`, and `refresh` for workflow templates (`implement_issue.txt`, `implement_pr.txt`, `add_issue.txt`).
+- New workflow template storage under AgentVault config (`~/.config/agentvault/templates/`) with metadata (`metadata.json`).
+- Setup bundle (`setup export/import/show`) now includes workflow template assets and metadata for cross-machine portability.
+- Precedence model for workflow templates: repository-local override -> config storage -> built-in default fallback with explicit warnings.
+
+### Tests
+- Added `internal/workflowtemplates` tests for precedence resolution, fallback warnings, import validation, and export/import metadata round-trip.
+
 ## [0.5.0] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ brew install nikolareljin/tap/agentvault
 | `setup export <file>` | Export complete configuration |
 | `setup import <file>` | Import configuration |
 | `setup pull` | Pull provider configs from system |
+| `templates list` | List workflow templates with effective source |
+| `templates show <name>` | Show effective workflow template |
+| `templates refresh` | Initialize/refresh config-stored templates |
 
 ## Provider Usage Status
 
@@ -193,6 +196,11 @@ Runtime value precedence for prompt execution is:
 - local agent setting in vault
 - process environment fallback (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OLLAMA_HOST`)
 - built-in default fallback (for Ollama base URL: `http://localhost:11434`)
+
+Workflow template precedence is:
+- repository-local override (`./implement_issue.txt`, `./implement_pr.txt`, `./add_issue.txt`)
+- config storage (`~/.config/agentvault/templates/`)
+- built-in defaults (with warning)
 
 In the TUI Agent detail view, effective values include source tags (`local`, `env`, `default`) for model/API key/base URL.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Runtime value precedence for prompt execution is:
 
 Workflow template precedence is:
 - repository-local override (`./implement_issue.txt`, `./implement_pr.txt`, `./add_issue.txt`)
-- config storage (`~/.config/agentvault/templates/`)
+- config storage (default: `~/.config/agentvault/templates/`; honors `XDG_CONFIG_HOME` and `--config`)
 - built-in defaults (with warning)
 
 In the TUI Agent detail view, effective values include source tags (`local`, `env`, `default`) for model/API key/base URL.

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -66,3 +66,22 @@ func TestRunTemplatesShow_AcceptsResolvedCustomFilename(t *testing.T) {
 		t.Fatalf("runTemplatesShow() output = %q, want custom template content", buf.String())
 	}
 }
+
+func TestFilterTemplateWarningsMatchesPathBasedCustomFilenameWarnings(t *testing.T) {
+	warnings := []string{
+		`template "/tmp/config/templates/custom-pr-template.txt" is empty; skipping`,
+		`template metadata is invalid; using safe fallbacks`,
+		`template "/tmp/config/templates/other.txt" is empty; skipping`,
+	}
+
+	filtered := filterTemplateWarnings(warnings, "implement_pr", "custom-pr-template.txt")
+	if len(filtered) != 2 {
+		t.Fatalf("filterTemplateWarnings() len = %d, want 2 (%v)", len(filtered), filtered)
+	}
+	if filtered[0] != warnings[0] && filtered[1] != warnings[0] {
+		t.Fatalf("expected path-based custom filename warning to be preserved, got %v", filtered)
+	}
+	if filtered[0] != warnings[1] && filtered[1] != warnings[1] {
+		t.Fatalf("expected metadata warning to be preserved, got %v", filtered)
+	}
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -16,5 +19,50 @@ func TestResolvePromptHistoryPath_UsesConfigOverride(t *testing.T) {
 	want := filepath.Join("/tmp/agentvault-custom", "prompt-history.jsonl")
 	if got != want {
 		t.Fatalf("resolvePromptHistoryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestRunTemplatesShow_AcceptsResolvedCustomFilename(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "templates"), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	customName := "custom-pr-template.txt"
+	if err := os.WriteFile(filepath.Join(cfgDir, "templates", customName), []byte("custom pr body\n"), 0600); err != nil {
+		t.Fatalf("WriteFile(custom): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "templates", "metadata.json"), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_pr": "`+customName+`"}
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = rootCmd.PersistentFlags().Set("config", "")
+	})
+	if err := rootCmd.PersistentFlags().Set("config", cfgDir); err != nil {
+		t.Fatalf("setting config flag: %v", err)
+	}
+
+	cmd := templatesShowCmd
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	if err := cmd.Flags().Set("repo", repoDir); err != nil {
+		t.Fatalf("setting repo flag: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Flags().Set("repo", "")
+		cmd.SetOut(nil)
+		cmd.SetErr(nil)
+	})
+
+	if err := runTemplatesShow(cmd, []string{customName}); err != nil {
+		t.Fatalf("runTemplatesShow() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "custom pr body") {
+		t.Fatalf("runTemplatesShow() output = %q, want custom template content", buf.String())
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@
 //	│   ├── to/vault/preview
 //	├── setup                  Full configuration export/import
 //	│   ├── export/import/show/apply/pull
-//	├── templates              Workflow templates (issue/PR/TODO flows)
+//	├── templates              Workflow templates (issue/PR/add-issue flows)
 //	│   ├── list/show/refresh
 //	├── instructions           Manage stored instruction files
 //	├── prompt                 Gateway prompt execution with usage tracking

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@
 //	│   ├── to/vault/preview
 //	├── setup                  Full configuration export/import
 //	│   ├── export/import/show/apply/pull
+//	├── templates              Workflow templates (issue/PR/TODO flows)
+//	│   ├── list/show/refresh
 //	├── instructions           Manage stored instruction files
 //	├── prompt                 Gateway prompt execution with usage tracking
 //	├── serve                  Start HTTP API server for vault integration

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -30,7 +30,7 @@ type SetupBundle struct {
 	Sessions        agent.SessionConfig      `json:"sessions,omitempty"`
 	SharedConfig    agent.SharedConfig       `json:"shared_config"`
 	ProviderConfigs agent.ProviderConfig     `json:"provider_configs"`
-	Templates       workflowtemplates.Bundle `json:"workflow_templates,omitempty"`
+	Templates       workflowtemplates.Bundle `json:"workflow_templates"`
 	StatusSnapshot  *statuspkg.Report        `json:"status_snapshot,omitempty"`
 	DetectedAgents  []DetectedAgent          `json:"detected_agents,omitempty"`
 	InstallGuide    InstallGuide             `json:"install_guide"`

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -215,7 +215,7 @@ func runSetupExport(cmd *cobra.Command, args []string) error {
 	}
 	bundle.Templates = templateBundle
 	for _, warn := range templateWarnings {
-		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", warn)
 	}
 
 	// Optionally strip API keys
@@ -476,7 +476,7 @@ func runSetupImport(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Imported: workflow templates (%d)\n", importedTemplates)
 		}
 		for _, warn := range templateWarnings {
-			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", warn)
 		}
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -468,12 +468,12 @@ func runSetupImport(cmd *cobra.Command, args []string) error {
 	}
 	// Backward compatibility: older bundles may not include workflow templates.
 	if bundle.Templates.SchemaVersion != "" || len(bundle.Templates.Assets) > 0 {
-		templateWarnings, err := workflowtemplates.ImportBundle(resolveConfigDir(), bundle.Templates)
+		importedTemplates, templateWarnings, err := workflowtemplates.ImportBundle(resolveConfigDir(), bundle.Templates)
 		if err != nil {
 			return fmt.Errorf("importing workflow templates: %w", err)
 		}
-		if len(bundle.Templates.Assets) > 0 {
-			fmt.Printf("  Imported: workflow templates (%d)\n", len(bundle.Templates.Assets))
+		if importedTemplates > 0 {
+			fmt.Printf("  Imported: workflow templates (%d)\n", importedTemplates)
 		}
 		for _, warn := range templateWarnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -466,15 +466,18 @@ func runSetupImport(cmd *cobra.Command, args []string) error {
 	if err := v.SetProviderConfigs(pc); err != nil {
 		return fmt.Errorf("updating provider configs: %w", err)
 	}
-	templateWarnings, err := workflowtemplates.ImportBundle(resolveConfigDir(), bundle.Templates)
-	if err != nil {
-		return fmt.Errorf("importing workflow templates: %w", err)
-	}
-	if len(bundle.Templates.Assets) > 0 {
-		fmt.Printf("  Imported: workflow templates (%d)\n", len(bundle.Templates.Assets))
-	}
-	for _, warn := range templateWarnings {
-		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+	// Backward compatibility: older bundles may not include workflow templates.
+	if bundle.Templates.SchemaVersion != "" || len(bundle.Templates.Assets) > 0 {
+		templateWarnings, err := workflowtemplates.ImportBundle(resolveConfigDir(), bundle.Templates)
+		if err != nil {
+			return fmt.Errorf("importing workflow templates: %w", err)
+		}
+		if len(bundle.Templates.Assets) > 0 {
+			fmt.Printf("  Imported: workflow templates (%d)\n", len(bundle.Templates.Assets))
+		}
+		for _, warn := range templateWarnings {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+		}
 	}
 
 	// Import sessions

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nikolareljin/agentvault/internal/agent"
 	"github.com/nikolareljin/agentvault/internal/crypto"
 	statuspkg "github.com/nikolareljin/agentvault/internal/status"
+	"github.com/nikolareljin/agentvault/internal/workflowtemplates"
 	"github.com/spf13/cobra"
 )
 
@@ -21,17 +22,18 @@ import (
 // across machines. It captures everything needed to recreate the environment:
 // agents, sessions, rules, roles, instructions, provider configs, and an installation guide.
 type SetupBundle struct {
-	Version         string               `json:"version"`
-	CreatedAt       time.Time            `json:"created_at"`
-	SourceMachine   string               `json:"source_machine"`
-	SourceOS        string               `json:"source_os"`
-	Agents          []agent.Agent        `json:"agents"`
-	Sessions        agent.SessionConfig  `json:"sessions,omitempty"`
-	SharedConfig    agent.SharedConfig   `json:"shared_config"`
-	ProviderConfigs agent.ProviderConfig `json:"provider_configs"`
-	StatusSnapshot  *statuspkg.Report    `json:"status_snapshot,omitempty"`
-	DetectedAgents  []DetectedAgent      `json:"detected_agents,omitempty"`
-	InstallGuide    InstallGuide         `json:"install_guide"`
+	Version         string                   `json:"version"`
+	CreatedAt       time.Time                `json:"created_at"`
+	SourceMachine   string                   `json:"source_machine"`
+	SourceOS        string                   `json:"source_os"`
+	Agents          []agent.Agent            `json:"agents"`
+	Sessions        agent.SessionConfig      `json:"sessions,omitempty"`
+	SharedConfig    agent.SharedConfig       `json:"shared_config"`
+	ProviderConfigs agent.ProviderConfig     `json:"provider_configs"`
+	Templates       workflowtemplates.Bundle `json:"workflow_templates,omitempty"`
+	StatusSnapshot  *statuspkg.Report        `json:"status_snapshot,omitempty"`
+	DetectedAgents  []DetectedAgent          `json:"detected_agents,omitempty"`
+	InstallGuide    InstallGuide             `json:"install_guide"`
 }
 
 // InstallGuide contains instructions for setting up agents on a new machine.
@@ -207,6 +209,14 @@ func runSetupExport(cmd *cobra.Command, args []string) error {
 		SharedConfig:    v.SharedConfig(),
 		ProviderConfigs: v.ProviderConfigs(),
 	}
+	templateBundle, templateWarnings, err := workflowtemplates.ExportBundle(resolveConfigDir())
+	if err != nil {
+		return fmt.Errorf("loading workflow templates for export: %w", err)
+	}
+	bundle.Templates = templateBundle
+	for _, warn := range templateWarnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+	}
 
 	// Optionally strip API keys
 	if !includeKeys {
@@ -274,6 +284,7 @@ func runSetupExport(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Agents: %d\n", len(bundle.Agents))
 	fmt.Printf("  Sessions: %d\n", len(bundle.Sessions.Sessions))
 	fmt.Printf("  Instructions: %d\n", len(bundle.SharedConfig.Instructions))
+	fmt.Printf("  Workflow templates: %d\n", len(bundle.Templates.Assets))
 	if includeKeys {
 		fmt.Println("  Warning: API keys are included!")
 	}
@@ -455,6 +466,16 @@ func runSetupImport(cmd *cobra.Command, args []string) error {
 	if err := v.SetProviderConfigs(pc); err != nil {
 		return fmt.Errorf("updating provider configs: %w", err)
 	}
+	templateWarnings, err := workflowtemplates.ImportBundle(resolveConfigDir(), bundle.Templates)
+	if err != nil {
+		return fmt.Errorf("importing workflow templates: %w", err)
+	}
+	if len(bundle.Templates.Assets) > 0 {
+		fmt.Printf("  Imported: workflow templates (%d)\n", len(bundle.Templates.Assets))
+	}
+	for _, warn := range templateWarnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+	}
 
 	// Import sessions
 	targetSessions := v.Sessions()
@@ -607,6 +628,12 @@ func runSetupShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\nInstructions (%d):\n", len(bundle.SharedConfig.Instructions))
 	for _, inst := range bundle.SharedConfig.Instructions {
 		fmt.Printf("  • %s -> %s (%d bytes)\n", inst.Name, inst.Filename, len(inst.Content))
+	}
+	if len(bundle.Templates.Assets) > 0 {
+		fmt.Printf("\nWorkflow Templates (%d):\n", len(bundle.Templates.Assets))
+		for _, tpl := range bundle.Templates.Assets {
+			fmt.Printf("  • %s (%s, version=%s)\n", tpl.Filename, tpl.Key, tpl.Version)
+		}
 	}
 
 	if bundle.SharedConfig.SystemPrompt != "" {

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 )
 
@@ -11,7 +10,11 @@ func TestSetupBundleMarshalIncludesWorkflowTemplatesField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshal(SetupBundle{}) error = %v", err)
 	}
-	if !strings.Contains(string(data), `"workflow_templates"`) {
-		t.Fatalf("marshal output = %s, want workflow_templates field present", string(data))
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(marshal output) error = %v", err)
+	}
+	if _, ok := payload["workflow_templates"]; !ok {
+		t.Fatalf("marshal output keys = %v, want workflow_templates field present", payload)
 	}
 }

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSetupBundleMarshalIncludesWorkflowTemplatesField(t *testing.T) {
+	data, err := json.Marshal(SetupBundle{})
+	if err != nil {
+		t.Fatalf("json.Marshal(SetupBundle{}) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"workflow_templates"`) {
+		t.Fatalf("marshal output = %s, want workflow_templates field present", string(data))
+	}
+}

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -96,7 +96,7 @@ func runTemplatesShow(cmd *cobra.Command, args []string) error {
 		if !strings.HasSuffix(t.Content, "\n") {
 			fmt.Println()
 		}
-		for _, warn := range warnings {
+		for _, warn := range filterTemplateWarnings(warnings, t.Key, t.Filename) {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
 		}
 		return nil
@@ -131,4 +131,23 @@ func resolveRepoDir(cmd *cobra.Command) (string, error) {
 		return "", fmt.Errorf("resolving repo path: %w", err)
 	}
 	return abs, nil
+}
+
+func filterTemplateWarnings(warnings []string, key string, filename string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	filtered := make([]string, 0, len(warnings))
+	for _, warningText := range warnings {
+		// Keep template-specific warnings for the selected template.
+		if strings.Contains(warningText, key) || strings.Contains(warningText, fmt.Sprintf("%q", filename)) {
+			filtered = append(filtered, warningText)
+			continue
+		}
+		// Keep global metadata-level warnings since they affect resolution semantics broadly.
+		if strings.Contains(strings.ToLower(warningText), "metadata") {
+			filtered = append(filtered, warningText)
+		}
+	}
+	return filtered
 }

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -28,7 +28,7 @@ var templatesListCmd = &cobra.Command{
 }
 
 var templatesShowCmd = &cobra.Command{
-	Use:   "show [name]",
+	Use:   "show <name>",
 	Short: "Show effective workflow template content",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runTemplatesShow,

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -111,7 +111,7 @@ func runTemplatesRefresh(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(written) == 0 {
-		fmt.Println("No templates written. Config storage is already initialized.")
+		fmt.Println("No template bodies were rewritten. Config storage metadata is up to date.")
 		return nil
 	}
 	fmt.Printf("Initialized %d workflow template(s) in config storage:\n", len(written))

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -61,12 +60,14 @@ func runTemplatesList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Workflow templates")
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+	fmt.Fprintln(out, "Workflow templates")
 	for _, t := range resolved {
-		fmt.Printf("  - %s (%s, version=%s)\n", t.Filename, t.Source, t.Version)
+		fmt.Fprintf(out, "  - %s (%s, version=%s)\n", t.Filename, t.Source, t.Version)
 	}
 	for _, warn := range warnings {
-		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+		fmt.Fprintf(errOut, "warning: %s\n", warn)
 	}
 	return nil
 }
@@ -76,32 +77,31 @@ func runTemplatesShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	wantKey, ok := workflowtemplates.FindTemplateKey(args[0])
-	if !ok {
-		return fmt.Errorf("unknown template %q; supported: %s", args[0], strings.Join(workflowtemplates.SupportedKeys(), ", "))
-	}
 	resolved, warnings, err := workflowtemplates.LoadResolved(resolveConfigDir(), repoDir)
 	if err != nil {
 		return err
 	}
+	requested := normalizeTemplateSelector(args[0])
 	includeMeta, _ := cmd.Flags().GetBool("metadata")
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
 	for _, t := range resolved {
-		if t.Key != wantKey {
+		if normalizeTemplateSelector(t.Key) != requested && normalizeTemplateSelector(t.Filename) != requested {
 			continue
 		}
 		if includeMeta {
-			fmt.Printf("# Source: %s\n# File: %s\n# Version: %s\n\n", t.Source, t.Filename, t.Version)
+			fmt.Fprintf(out, "# Source: %s\n# File: %s\n# Version: %s\n\n", t.Source, t.Filename, t.Version)
 		}
-		fmt.Print(t.Content)
+		fmt.Fprint(out, t.Content)
 		if !strings.HasSuffix(t.Content, "\n") {
-			fmt.Println()
+			fmt.Fprintln(out)
 		}
 		for _, warn := range filterTemplateWarnings(warnings, t.Key, t.Filename) {
-			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+			fmt.Fprintf(errOut, "warning: %s\n", warn)
 		}
 		return nil
 	}
-	return fmt.Errorf("template %q was not resolved", wantKey)
+	return fmt.Errorf("unknown template %q; supported: %s", args[0], strings.Join(workflowtemplates.SupportedKeys(), ", "))
 }
 
 func runTemplatesRefresh(cmd *cobra.Command, args []string) error {
@@ -110,13 +110,14 @@ func runTemplatesRefresh(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	out := cmd.OutOrStdout()
 	if len(written) == 0 {
-		fmt.Println("No template bodies were rewritten. Config storage metadata is up to date.")
+		fmt.Fprintln(out, "No template bodies were rewritten. Config storage metadata is up to date.")
 		return nil
 	}
-	fmt.Printf("Initialized %d workflow template(s) in config storage:\n", len(written))
+	fmt.Fprintf(out, "Initialized %d workflow template(s) in config storage:\n", len(written))
 	for _, t := range written {
-		fmt.Printf("  - %s (%s)\n", t.Filename, t.Version)
+		fmt.Fprintf(out, "  - %s (%s)\n", t.Filename, t.Version)
 	}
 	return nil
 }
@@ -150,4 +151,11 @@ func filterTemplateWarnings(warnings []string, key string, filename string) []st
 		}
 	}
 	return filtered
+}
+
+func normalizeTemplateSelector(value string) string {
+	v := strings.TrimSpace(strings.ToLower(value))
+	v = strings.TrimSuffix(v, ".txt")
+	v = strings.ReplaceAll(v, "-", "_")
+	return v
 }

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nikolareljin/agentvault/internal/workflowtemplates"
+	"github.com/spf13/cobra"
+)
+
+var templatesCmd = &cobra.Command{
+	Use:   "templates",
+	Short: "Manage workflow templates used by issue/PR automation workflows",
+	Long: `Workflow templates are resolved with explicit precedence:
+  1) repository-local files (./implement_issue.txt, etc.)
+  2) AgentVault config storage (~/.config/agentvault/templates)
+  3) built-in safe defaults
+
+Use these commands to inspect effective content and refresh config templates.`,
+}
+
+var templatesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List workflow templates and effective source",
+	RunE:  runTemplatesList,
+}
+
+var templatesShowCmd = &cobra.Command{
+	Use:   "show [name]",
+	Short: "Show effective workflow template content",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTemplatesShow,
+}
+
+var templatesRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Write built-in templates into config storage",
+	RunE:  runTemplatesRefresh,
+}
+
+func init() {
+	rootCmd.AddCommand(templatesCmd)
+	templatesCmd.AddCommand(templatesListCmd)
+	templatesCmd.AddCommand(templatesShowCmd)
+	templatesCmd.AddCommand(templatesRefreshCmd)
+
+	templatesListCmd.Flags().String("repo", "", "repository path for repo-local overrides (default: current directory)")
+	templatesShowCmd.Flags().String("repo", "", "repository path for repo-local overrides (default: current directory)")
+	templatesShowCmd.Flags().Bool("metadata", false, "include metadata header before template content")
+	templatesRefreshCmd.Flags().Bool("force", false, "overwrite existing config templates with built-in defaults")
+}
+
+func runTemplatesList(cmd *cobra.Command, args []string) error {
+	repoDir, err := resolveRepoDir(cmd)
+	if err != nil {
+		return err
+	}
+	resolved, warnings, err := workflowtemplates.LoadResolved(resolveConfigDir(), repoDir)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Workflow templates")
+	for _, t := range resolved {
+		fmt.Printf("  - %s (%s, version=%s)\n", t.Filename, t.Source, t.Version)
+	}
+	for _, warn := range warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+	}
+	return nil
+}
+
+func runTemplatesShow(cmd *cobra.Command, args []string) error {
+	repoDir, err := resolveRepoDir(cmd)
+	if err != nil {
+		return err
+	}
+	wantFile, ok := workflowtemplates.FindTemplateFilename(args[0])
+	if !ok {
+		return fmt.Errorf("unknown template %q; supported: %s", args[0], strings.Join(workflowtemplates.SupportedKeys(), ", "))
+	}
+	resolved, warnings, err := workflowtemplates.LoadResolved(resolveConfigDir(), repoDir)
+	if err != nil {
+		return err
+	}
+	includeMeta, _ := cmd.Flags().GetBool("metadata")
+	for _, t := range resolved {
+		if t.Filename != wantFile {
+			continue
+		}
+		if includeMeta {
+			fmt.Printf("# Source: %s\n# File: %s\n# Version: %s\n\n", t.Source, t.Filename, t.Version)
+		}
+		fmt.Print(t.Content)
+		if !strings.HasSuffix(t.Content, "\n") {
+			fmt.Println()
+		}
+		for _, warn := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", warn)
+		}
+		return nil
+	}
+	return fmt.Errorf("template %q was not resolved", wantFile)
+}
+
+func runTemplatesRefresh(cmd *cobra.Command, args []string) error {
+	force, _ := cmd.Flags().GetBool("force")
+	written, err := workflowtemplates.RefreshConfigTemplates(resolveConfigDir(), force)
+	if err != nil {
+		return err
+	}
+	if len(written) == 0 {
+		fmt.Println("No templates written. Config storage is already initialized.")
+		return nil
+	}
+	fmt.Printf("Initialized %d workflow template(s) in config storage:\n", len(written))
+	for _, t := range written {
+		fmt.Printf("  - %s (%s)\n", t.Filename, t.Version)
+	}
+	return nil
+}
+
+func resolveRepoDir(cmd *cobra.Command) (string, error) {
+	repoDir, _ := cmd.Flags().GetString("repo")
+	if strings.TrimSpace(repoDir) == "" {
+		repoDir = "."
+	}
+	abs, err := filepath.Abs(repoDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving repo path: %w", err)
+	}
+	return abs, nil
+}

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -15,7 +15,7 @@ var templatesCmd = &cobra.Command{
 	Short: "Manage workflow templates used by issue/PR automation workflows",
 	Long: `Workflow templates are resolved with explicit precedence:
   1) repository-local files (./implement_issue.txt, etc.)
-  2) AgentVault config storage (~/.config/agentvault/templates)
+  2) AgentVault config storage (default: ~/.config/agentvault/templates; honors XDG_CONFIG_HOME/--config)
   3) built-in safe defaults
 
 Use these commands to inspect effective content and refresh config templates.`,

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -76,7 +76,7 @@ func runTemplatesShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	wantFile, ok := workflowtemplates.FindTemplateFilename(args[0])
+	wantKey, ok := workflowtemplates.FindTemplateKey(args[0])
 	if !ok {
 		return fmt.Errorf("unknown template %q; supported: %s", args[0], strings.Join(workflowtemplates.SupportedKeys(), ", "))
 	}
@@ -86,7 +86,7 @@ func runTemplatesShow(cmd *cobra.Command, args []string) error {
 	}
 	includeMeta, _ := cmd.Flags().GetBool("metadata")
 	for _, t := range resolved {
-		if t.Filename != wantFile {
+		if t.Key != wantKey {
 			continue
 		}
 		if includeMeta {
@@ -101,7 +101,7 @@ func runTemplatesShow(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("template %q was not resolved", wantFile)
+	return fmt.Errorf("template %q was not resolved", wantKey)
 }
 
 func runTemplatesRefresh(cmd *cobra.Command, args []string) error {

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -139,9 +139,10 @@ func filterTemplateWarnings(warnings []string, key string, filename string) []st
 		return nil
 	}
 	filtered := make([]string, 0, len(warnings))
+	quotedFilename := fmt.Sprintf("%q", filename)
 	for _, warningText := range warnings {
 		// Keep template-specific warnings for the selected template.
-		if strings.Contains(warningText, key) || strings.Contains(warningText, fmt.Sprintf("%q", filename)) {
+		if strings.Contains(warningText, key) || strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, filename) {
 			filtered = append(filtered, warningText)
 			continue
 		}

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -418,7 +418,7 @@ Flags:
 - `--encrypted` (default: `false`)
 - `--plain` (default: `false`)
 
-`setup export` also includes workflow templates from AgentVault config storage (`~/.config/agentvault/templates/`) with template version metadata.
+`setup export` also includes workflow templates from AgentVault config storage (default: `~/.config/agentvault/templates/`; honors `XDG_CONFIG_HOME` and `--config`) with template version metadata.
 
 ### `agentvault setup import [file]`
 Flags:
@@ -443,7 +443,7 @@ Flags:
 
 Workflow template precedence:
 1. repository-local override (`./implement_issue.txt`, `./implement_pr.txt`, `./add_issue.txt`)
-2. AgentVault config storage (`~/.config/agentvault/templates/`)
+2. AgentVault config storage (default: `~/.config/agentvault/templates/`; honors `XDG_CONFIG_HOME` and `--config`)
 3. built-in defaults (safe fallback with warning)
 
 ### `agentvault templates list`

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -418,6 +418,8 @@ Flags:
 - `--encrypted` (default: `false`)
 - `--plain` (default: `false`)
 
+`setup export` also includes workflow templates from AgentVault config storage (`~/.config/agentvault/templates/`) with template version metadata.
+
 ### `agentvault setup import [file]`
 Flags:
 - `--merge` (default: `false`)
@@ -437,7 +439,23 @@ Flags:
 - `--codex` (default: `false`)
 - `--ollama` (default: `false`)
 
-## 3.12 Legacy vault export/import commands
+## 3.12 Workflow templates
+
+Workflow template precedence:
+1. repository-local override (`./implement_issue.txt`, `./implement_pr.txt`, `./add_issue.txt`)
+2. AgentVault config storage (`~/.config/agentvault/templates/`)
+3. built-in defaults (safe fallback with warning)
+
+### `agentvault templates list`
+List effective templates and their source.
+
+### `agentvault templates show [name]`
+Show effective template content by key or filename.
+
+### `agentvault templates refresh`
+Initialize or refresh config-stored templates from built-in defaults.
+
+## 3.13 Legacy vault export/import commands
 
 ### `agentvault export [file]`
 Flags:

--- a/docs/USAGE_DETAILED.md
+++ b/docs/USAGE_DETAILED.md
@@ -449,7 +449,7 @@ Workflow template precedence:
 ### `agentvault templates list`
 List effective templates and their source.
 
-### `agentvault templates show [name]`
+### `agentvault templates show <name>`
 Show effective template content by key or filename.
 
 ### `agentvault templates refresh`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -373,7 +373,7 @@ Flags:
 Flags:
 - `--repo <path>` (default: current directory)
 
-### `agentvault templates show [name]`
+### `agentvault templates show <name>`
 Flags:
 - `--repo <path>` (default: current directory)
 - `--metadata` (default: `false`)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -367,6 +367,21 @@ Flags:
 - `--codex` (default: `false`)
 - `--ollama` (default: `false`)
 
+## Templates
+
+### `agentvault templates list`
+Flags:
+- `--repo <path>` (default: current directory)
+
+### `agentvault templates show [name]`
+Flags:
+- `--repo <path>` (default: current directory)
+- `--metadata` (default: `false`)
+
+### `agentvault templates refresh`
+Flags:
+- `--force` (default: `false`)
+
 ## Legacy export/import
 
 ### `agentvault export [file]`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,3 +29,8 @@ func VaultPath() string {
 func ConfigPath() string {
 	return filepath.Join(Dir(), ConfigFile)
 }
+
+// TemplatesDir returns the template storage directory.
+func TemplatesDir() string {
+	return filepath.Join(Dir(), "templates")
+}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -363,28 +363,56 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 
 	written := make([]TemplateAsset, 0, len(defaultSpecs))
 	for _, spec := range defaultSpecs {
-		path := filepath.Join(templatesDir, spec.Filename)
+		filename := spec.Filename
+		if meta.Filenames != nil {
+			if mfn := strings.TrimSpace(meta.Filenames[spec.Key]); mfn != "" {
+				safeFilename, err := sanitizeTemplateFilename(mfn)
+				if err == nil {
+					filename = safeFilename
+				}
+			}
+		}
+		path := filepath.Join(templatesDir, filename)
 		if !force {
 			if content, ok, _ := readTemplateFile(path); ok && strings.TrimSpace(content) != "" {
 				if _, ok := meta.Versions[spec.Key]; !ok {
 					meta.Versions[spec.Key] = spec.Version
 				}
 				if _, ok := meta.Filenames[spec.Key]; !ok {
-					meta.Filenames[spec.Key] = spec.Filename
+					meta.Filenames[spec.Key] = filename
 				}
 				if _, ok := meta.Updated[spec.Key]; !ok {
 					meta.Updated[spec.Key] = now
 				}
 				continue
 			}
+			if filename != spec.Filename {
+				canonicalPath := filepath.Join(templatesDir, spec.Filename)
+				if content, ok, _ := readTemplateFile(canonicalPath); ok && strings.TrimSpace(content) != "" {
+					if _, ok := meta.Versions[spec.Key]; !ok {
+						meta.Versions[spec.Key] = spec.Version
+					}
+					meta.Filenames[spec.Key] = spec.Filename
+					if _, ok := meta.Updated[spec.Key]; !ok {
+						meta.Updated[spec.Key] = now
+					}
+					continue
+				}
+			}
 		}
 		if err := os.WriteFile(path, []byte(spec.Content), 0600); err != nil {
-			return nil, fmt.Errorf("writing template %s: %w", spec.Filename, err)
+			return nil, fmt.Errorf("writing template %s: %w", filename, err)
 		}
 		meta.Versions[spec.Key] = spec.Version
 		meta.Updated[spec.Key] = now
-		meta.Filenames[spec.Key] = spec.Filename
-		written = append(written, spec)
+		meta.Filenames[spec.Key] = filename
+		written = append(written, TemplateAsset{
+			Key:       spec.Key,
+			Filename:  filename,
+			Version:   spec.Version,
+			UpdatedAt: now,
+			Content:   spec.Content,
+		})
 	}
 	meta.UpdatedAt = now
 	if err := writeMetadata(configDir, meta); err != nil {
@@ -584,6 +612,7 @@ func hasSpecificTemplateWarning(warnings []string, key, filename string) bool {
 		"corrupt",
 		"invalid",
 		"malformed",
+		"missing",
 	}
 	for _, warningText := range warnings {
 		if !(strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, key)) {

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -234,7 +234,9 @@ func ExportBundle(configDir string) (Bundle, []string, error) {
 				delete(byKey, spec.Key)
 				continue
 			}
-			warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; exporting built-in default", spec.Filename))
+			if !hasSpecificTemplateWarning(warnings, spec.Key, spec.Filename) {
+				warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; exporting built-in default", spec.Filename))
+			}
 			merged = append(merged, spec)
 		}
 		assets = merged

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -199,7 +199,9 @@ func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []strin
 			continue
 		}
 
-		warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; using built-in default", spec.Filename))
+		if !hasSpecificTemplateWarning(warnings, spec.Key, spec.Filename) {
+			warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; using built-in default", spec.Filename))
+		}
 		resolved = append(resolved, ResolvedTemplate{
 			TemplateAsset: spec,
 			Source:        "built-in",
@@ -219,6 +221,25 @@ func ExportBundle(configDir string) (Bundle, []string, error) {
 	if len(assets) == 0 {
 		assets = cloneDefaults()
 		warnings = append(warnings, "no workflow templates found in config storage; exporting built-in defaults")
+	} else {
+		byKey := make(map[string]TemplateAsset, len(assets))
+		for _, asset := range assets {
+			byKey[asset.Key] = asset
+		}
+		merged := make([]TemplateAsset, 0, len(defaultSpecs)+len(assets))
+		for _, spec := range defaultSpecs {
+			if asset, ok := byKey[spec.Key]; ok && strings.TrimSpace(asset.Content) != "" {
+				merged = append(merged, asset)
+				delete(byKey, spec.Key)
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; exporting built-in default", spec.Filename))
+			merged = append(merged, spec)
+		}
+		for _, asset := range byKey {
+			merged = append(merged, asset)
+		}
+		assets = merged
 	}
 	sort.Slice(assets, func(i, j int) bool { return assets[i].Filename < assets[j].Filename })
 	return Bundle{
@@ -236,7 +257,7 @@ func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
 	if len(bundle.Assets) == 0 {
 		return []string{"bundle did not include workflow templates; nothing imported"}, nil
 	}
-	if err := os.MkdirAll(configTemplatesDir(configDir), 0755); err != nil {
+	if err := os.MkdirAll(configTemplatesDir(configDir), 0700); err != nil {
 		return nil, fmt.Errorf("creating templates directory: %w", err)
 	}
 	meta := metadataFile{
@@ -269,7 +290,7 @@ func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
 			warnings = append(warnings, fmt.Sprintf("skipped empty template %q", filename))
 			continue
 		}
-		if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), filename), []byte(asset.Content), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), filename), []byte(asset.Content), 0600); err != nil {
 			return nil, fmt.Errorf("writing template %s: %w", filename, err)
 		}
 		meta.Versions[asset.Key] = firstNonEmpty(asset.Version, "imported")
@@ -285,7 +306,7 @@ func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
 // RefreshConfigTemplates ensures config storage contains default templates and metadata.
 func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, error) {
 	templatesDir := configTemplatesDir(configDir)
-	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+	if err := os.MkdirAll(templatesDir, 0700); err != nil {
 		return nil, fmt.Errorf("creating templates directory: %w", err)
 	}
 	now := time.Now().UTC()
@@ -317,7 +338,7 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 				continue
 			}
 		}
-		if err := os.WriteFile(path, []byte(spec.Content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(spec.Content), 0600); err != nil {
 			return nil, fmt.Errorf("writing template %s: %w", spec.Filename, err)
 		}
 		meta.Versions[spec.Key] = spec.Version
@@ -419,14 +440,14 @@ func writeMetadata(configDir string, meta metadataFile) error {
 	if meta.SchemaVersion == "" {
 		meta.SchemaVersion = DefaultSchemaVersion
 	}
-	if err := os.MkdirAll(configTemplatesDir(configDir), 0755); err != nil {
+	if err := os.MkdirAll(configTemplatesDir(configDir), 0700); err != nil {
 		return fmt.Errorf("creating templates directory: %w", err)
 	}
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encoding metadata: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), metadataFileName), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), metadataFileName), data, 0600); err != nil {
 		return fmt.Errorf("writing metadata: %w", err)
 	}
 	return nil
@@ -503,6 +524,19 @@ func dedupeWarnings(warnings []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func hasSpecificTemplateWarning(warnings []string, key, filename string) bool {
+	if len(warnings) == 0 {
+		return false
+	}
+	quotedFilename := fmt.Sprintf("%q", filename)
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, key) {
+			return true
+		}
+	}
+	return false
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -283,6 +283,7 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 		meta.Filenames = make(map[string]string)
 	}
 	importedCount := 0
+	seenKeys := make(map[string]struct{})
 	seenFilenames := make(map[string]string)
 	for _, asset := range bundle.Assets {
 		asset.Key = normalizeTemplateName(asset.Key)
@@ -295,6 +296,10 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 			warnings = append(warnings, fmt.Sprintf("skipped unsupported template key %q", asset.Key))
 			continue
 		}
+		if _, exists := seenKeys[asset.Key]; exists {
+			return 0, nil, fmt.Errorf("duplicate template key %q in bundle", asset.Key)
+		}
+		seenKeys[asset.Key] = struct{}{}
 		filename := asset.Filename
 		if filename == "" {
 			filename = defaultSpec.Filename
@@ -398,6 +403,7 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 	assets := make([]TemplateAsset, 0, len(defaultSpecs))
 	for _, spec := range defaultSpecs {
 		filename := spec.Filename
+		usedMetadataFilename := false
 		if meta.Filenames != nil {
 			if mfn := strings.TrimSpace(meta.Filenames[spec.Key]); mfn != "" {
 				safeFilename, err := sanitizeTemplateFilename(mfn)
@@ -405,6 +411,7 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 					warnings = append(warnings, fmt.Sprintf("ignoring unsafe metadata filename for %q: %v", spec.Key, err))
 				} else {
 					filename = safeFilename
+					usedMetadataFilename = safeFilename != spec.Filename
 				}
 			}
 		}
@@ -413,6 +420,8 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 		if !ok {
 			if warn != "" {
 				warnings = append(warnings, warn)
+			} else if usedMetadataFilename {
+				warnings = append(warnings, fmt.Sprintf("template %q referenced by metadata for %q is missing; falling back", filename, spec.Key))
 			}
 			continue
 		}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -280,6 +280,7 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 	}
 	warnings := make([]string, 0)
 	importedCount := 0
+	seenFilenames := make(map[string]string)
 	for _, asset := range bundle.Assets {
 		asset.Key = normalizeTemplateName(asset.Key)
 		if asset.Key == "" {
@@ -299,6 +300,10 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 		if err != nil {
 			return 0, nil, fmt.Errorf("invalid filename for template key %q: %w", asset.Key, err)
 		}
+		if existingKey, exists := seenFilenames[filename]; exists {
+			return 0, nil, fmt.Errorf("duplicate template filename %q for keys %q and %q", filename, existingKey, asset.Key)
+		}
+		seenFilenames[filename] = asset.Key
 		if strings.TrimSpace(asset.Content) == "" {
 			warnings = append(warnings, fmt.Sprintf("skipped empty template %q", filename))
 			continue

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -139,7 +139,7 @@ func SupportedKeys() []string {
 func FindTemplateFilename(name string) (string, bool) {
 	norm := normalizeTemplateName(name)
 	for _, spec := range defaultSpecs {
-		if norm == spec.Key || norm == spec.Filename {
+		if norm == spec.Key || norm == normalizeTemplateName(spec.Filename) {
 			return spec.Filename, true
 		}
 	}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -177,7 +177,7 @@ func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []strin
 					TemplateAsset: TemplateAsset{
 						Key:       spec.Key,
 						Filename:  spec.Filename,
-						Version:   "repo-local",
+						Version:   spec.Version,
 						UpdatedAt: time.Time{},
 						Content:   content,
 					},
@@ -246,62 +246,76 @@ func ExportBundle(configDir string) (Bundle, []string, error) {
 	}, dedupeWarnings(warnings), nil
 }
 
-// ImportBundle writes template assets into config storage.
-func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
+// ImportBundle writes template assets into config storage and returns imported asset count.
+func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 	if bundle.SchemaVersion != "" && bundle.SchemaVersion != DefaultSchemaVersion {
-		return nil, fmt.Errorf("unsupported template bundle schema version %q", bundle.SchemaVersion)
+		return 0, nil, fmt.Errorf("unsupported template bundle schema version %q", bundle.SchemaVersion)
 	}
 	if len(bundle.Assets) == 0 {
-		return []string{"bundle did not include workflow templates; nothing imported"}, nil
+		return 0, []string{"bundle did not include workflow templates; nothing imported"}, nil
 	}
 	if err := os.MkdirAll(configTemplatesDir(configDir), 0700); err != nil {
-		return nil, fmt.Errorf("creating templates directory: %w", err)
+		return 0, nil, fmt.Errorf("creating templates directory: %w", err)
 	}
-	meta := metadataFile{
-		SchemaVersion: DefaultSchemaVersion,
-		UpdatedAt:     time.Now().UTC(),
-		Versions:      make(map[string]string),
-		Updated:       make(map[string]time.Time),
-		Filenames:     make(map[string]string),
+	meta, metaErr := readMetadata(configDir)
+	if metaErr != nil {
+		if !errors.Is(metaErr, os.ErrNotExist) {
+			return 0, nil, fmt.Errorf("reading existing template metadata: %w", metaErr)
+		}
+		meta = metadataFile{
+			SchemaVersion: DefaultSchemaVersion,
+		}
+	}
+	if meta.SchemaVersion == "" {
+		meta.SchemaVersion = DefaultSchemaVersion
+	}
+	if meta.Versions == nil {
+		meta.Versions = make(map[string]string)
+	}
+	if meta.Updated == nil {
+		meta.Updated = make(map[string]time.Time)
+	}
+	if meta.Filenames == nil {
+		meta.Filenames = make(map[string]string)
 	}
 	warnings := make([]string, 0)
+	importedCount := 0
 	for _, asset := range bundle.Assets {
 		asset.Key = normalizeTemplateName(asset.Key)
 		if asset.Key == "" {
 			warnings = append(warnings, "skipped template with empty key")
 			continue
 		}
-		if _, supported := findDefaultByKey(asset.Key); !supported {
+		defaultSpec, supported := findDefaultByKey(asset.Key)
+		if !supported {
 			warnings = append(warnings, fmt.Sprintf("skipped unsupported template key %q", asset.Key))
 			continue
 		}
 		filename := asset.Filename
 		if filename == "" {
-			if def, ok := findDefaultByKey(asset.Key); ok {
-				filename = def.Filename
-			} else {
-				filename = asset.Key + ".txt"
-			}
+			filename = defaultSpec.Filename
 		}
 		filename, err := sanitizeTemplateFilename(filename)
 		if err != nil {
-			return nil, fmt.Errorf("invalid filename for template key %q: %w", asset.Key, err)
+			return 0, nil, fmt.Errorf("invalid filename for template key %q: %w", asset.Key, err)
 		}
 		if strings.TrimSpace(asset.Content) == "" {
 			warnings = append(warnings, fmt.Sprintf("skipped empty template %q", filename))
 			continue
 		}
 		if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), filename), []byte(asset.Content), 0600); err != nil {
-			return nil, fmt.Errorf("writing template %s: %w", filename, err)
+			return 0, nil, fmt.Errorf("writing template %s: %w", filename, err)
 		}
 		meta.Versions[asset.Key] = firstNonEmpty(asset.Version, "imported")
 		meta.Updated[asset.Key] = nonZeroTime(asset.UpdatedAt, time.Now().UTC())
 		meta.Filenames[asset.Key] = filename
+		importedCount++
 	}
+	meta.UpdatedAt = time.Now().UTC()
 	if err := writeMetadata(configDir, meta); err != nil {
-		return nil, err
+		return 0, nil, err
 	}
-	return dedupeWarnings(warnings), nil
+	return importedCount, dedupeWarnings(warnings), nil
 }
 
 // RefreshConfigTemplates ensures config storage contains default templates and metadata.

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -448,10 +448,9 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 		path := filepath.Join(configTemplatesDir(configDir), selectedFilename)
 		content, ok, warn := readTemplateFile(path)
 		if !ok {
+			fallbackTarget := "built-in default template"
 			if warn != "" {
 				warnings = append(warnings, warn)
-			} else if usedMetadataFilename {
-				warnings = append(warnings, fmt.Sprintf("template %q referenced by metadata for %q is missing; falling back", selectedFilename, spec.Key))
 			}
 			if usedMetadataFilename {
 				canonicalPath := filepath.Join(configTemplatesDir(configDir), spec.Filename)
@@ -460,8 +459,12 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 					content = canonicalContent
 					ok = true
 					selectedFilename = spec.Filename
+					fallbackTarget = fmt.Sprintf("canonical config template %q", spec.Filename)
 				} else if canonicalWarn != "" {
 					warnings = append(warnings, canonicalWarn)
+				}
+				if warn == "" {
+					warnings = append(warnings, fmt.Sprintf("template %q referenced by metadata for %q is missing; falling back to %s", path, spec.Key, fallbackTarget))
 				}
 			}
 		}
@@ -500,11 +503,11 @@ func readTemplateFile(path string) (string, bool, string) {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", false, ""
 		}
-		return "", false, fmt.Sprintf("cannot read template %q; skipping (%v)", filepath.Base(path), err)
+		return "", false, fmt.Sprintf("cannot read template %q; skipping (%v)", path, err)
 	}
 	content := strings.TrimSpace(string(data))
 	if content == "" {
-		return "", false, fmt.Sprintf("template %q is empty; skipping", filepath.Base(path))
+		return "", false, fmt.Sprintf("template %q is empty; skipping", path)
 	}
 	return string(data), true, ""
 }

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -629,6 +629,8 @@ func hasSpecificTemplateWarning(warnings []string, key, filename string) bool {
 		"can't read",
 		"failed to read",
 		"unreadable",
+		"conflict",
+		"conflicts",
 		"corrupt",
 		"invalid",
 		"malformed",

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -257,10 +257,12 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 	if err := os.MkdirAll(configTemplatesDir(configDir), 0700); err != nil {
 		return 0, nil, fmt.Errorf("creating templates directory: %w", err)
 	}
+	warnings := make([]string, 0)
 	meta, metaErr := readMetadata(configDir)
 	if metaErr != nil {
 		if !errors.Is(metaErr, os.ErrNotExist) {
-			return 0, nil, fmt.Errorf("reading existing template metadata: %w", metaErr)
+			// Allow bundle import to repair corrupted metadata by resetting to defaults.
+			warnings = append(warnings, fmt.Sprintf("existing template metadata invalid; resetting metadata defaults (%v)", metaErr))
 		}
 		meta = metadataFile{
 			SchemaVersion: DefaultSchemaVersion,
@@ -278,7 +280,6 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 	if meta.Filenames == nil {
 		meta.Filenames = make(map[string]string)
 	}
-	warnings := make([]string, 0)
 	importedCount := 0
 	seenFilenames := make(map[string]string)
 	for _, asset := range bundle.Assets {
@@ -330,7 +331,13 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 		return nil, fmt.Errorf("creating templates directory: %w", err)
 	}
 	now := time.Now().UTC()
-	meta, _ := readMetadata(configDir)
+	meta, metaErr := readMetadata(configDir)
+	if metaErr != nil {
+		if !errors.Is(metaErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("reading template metadata: %w", metaErr)
+		}
+		meta = metadataFile{}
+	}
 	if meta.SchemaVersion == "" {
 		meta.SchemaVersion = DefaultSchemaVersion
 	}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -429,6 +429,7 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 	}
 
 	assets := make([]TemplateAsset, 0, len(defaultSpecs))
+	seenFilenames := make(map[string]string, len(defaultSpecs))
 	for _, spec := range defaultSpecs {
 		filename := spec.Filename
 		usedMetadataFilename := false
@@ -482,6 +483,11 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 		if meta.Updated != nil {
 			asset.UpdatedAt = meta.Updated[spec.Key]
 		}
+		if existingKey, exists := seenFilenames[asset.Filename]; exists {
+			warnings = append(warnings, fmt.Sprintf("template %q for %q conflicts with %q; falling back to built-in default", asset.Filename, spec.Key, existingKey))
+			continue
+		}
+		seenFilenames[asset.Filename] = spec.Key
 		assets = append(assets, asset)
 	}
 

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -531,9 +531,25 @@ func hasSpecificTemplateWarning(warnings []string, key, filename string) bool {
 		return false
 	}
 	quotedFilename := fmt.Sprintf("%q", filename)
+	unusableIndicators := []string{
+		"empty",
+		"cannot read",
+		"can't read",
+		"failed to read",
+		"unreadable",
+		"corrupt",
+		"invalid",
+		"malformed",
+	}
 	for _, warningText := range warnings {
-		if strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, key) {
-			return true
+		if !(strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, key)) {
+			continue
+		}
+		lowered := strings.ToLower(warningText)
+		for _, indicator := range unusableIndicators {
+			if strings.Contains(lowered, indicator) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -236,9 +236,6 @@ func ExportBundle(configDir string) (Bundle, []string, error) {
 			warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; exporting built-in default", spec.Filename))
 			merged = append(merged, spec)
 		}
-		for _, asset := range byKey {
-			merged = append(merged, asset)
-		}
 		assets = merged
 	}
 	sort.Slice(assets, func(i, j int) bool { return assets[i].Filename < assets[j].Filename })
@@ -272,6 +269,10 @@ func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
 		asset.Key = normalizeTemplateName(asset.Key)
 		if asset.Key == "" {
 			warnings = append(warnings, "skipped template with empty key")
+			continue
+		}
+		if _, supported := findDefaultByKey(asset.Key); !supported {
+			warnings = append(warnings, fmt.Sprintf("skipped unsupported template key %q", asset.Key))
 			continue
 		}
 		filename := asset.Filename
@@ -334,6 +335,9 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 				}
 				if _, ok := meta.Filenames[spec.Key]; !ok {
 					meta.Filenames[spec.Key] = spec.Filename
+				}
+				if _, ok := meta.Updated[spec.Key]; !ok {
+					meta.Updated[spec.Key] = now
 				}
 				continue
 			}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -642,7 +642,7 @@ func hasSpecificTemplateWarning(warnings []string, key, filename string) bool {
 		"missing",
 	}
 	for _, warningText := range warnings {
-		if !(strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, key)) {
+		if !(strings.Contains(warningText, quotedFilename) || strings.Contains(warningText, filename) || strings.Contains(warningText, key)) {
 			continue
 		}
 		lowered := strings.ToLower(warningText)

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -43,12 +43,11 @@ type ResolvedTemplate struct {
 }
 
 type metadataFile struct {
-	SchemaVersion string                     `json:"schema_version"`
-	UpdatedAt     time.Time                  `json:"updated_at,omitempty"`
-	Versions      map[string]string          `json:"versions,omitempty"`
-	Updated       map[string]time.Time       `json:"updated,omitempty"`
-	Filenames     map[string]string          `json:"filenames,omitempty"`
-	Extra         map[string]json.RawMessage `json:"-"`
+	SchemaVersion string               `json:"schema_version"`
+	UpdatedAt     time.Time            `json:"updated_at,omitempty"`
+	Versions      map[string]string    `json:"versions,omitempty"`
+	Updated       map[string]time.Time `json:"updated,omitempty"`
+	Filenames     map[string]string    `json:"filenames,omitempty"`
 }
 
 var defaultSpecs = []TemplateAsset{
@@ -410,10 +409,16 @@ func readMetadata(configDir string) (metadataFile, error) {
 	if meta.SchemaVersion == "" {
 		meta.SchemaVersion = DefaultSchemaVersion
 	}
+	if meta.SchemaVersion != DefaultSchemaVersion {
+		return metadataFile{}, fmt.Errorf("unsupported metadata schema version %q", meta.SchemaVersion)
+	}
 	return meta, nil
 }
 
 func writeMetadata(configDir string, meta metadataFile) error {
+	if meta.SchemaVersion == "" {
+		meta.SchemaVersion = DefaultSchemaVersion
+	}
 	if err := os.MkdirAll(configTemplatesDir(configDir), 0755); err != nil {
 		return fmt.Errorf("creating templates directory: %w", err)
 	}

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -147,6 +147,17 @@ func FindTemplateFilename(name string) (string, bool) {
 	return "", false
 }
 
+// FindTemplateKey resolves a key or filename into the canonical key.
+func FindTemplateKey(name string) (string, bool) {
+	norm := normalizeTemplateName(name)
+	for _, spec := range defaultSpecs {
+		if norm == spec.Key || norm == normalizeTemplateName(spec.Filename) {
+			return spec.Key, true
+		}
+	}
+	return "", false
+}
+
 // LoadResolved loads effective templates with precedence repo-local > config > built-in.
 func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []string, error) {
 	assets, warnings, err := loadConfigAssets(configDir)
@@ -184,7 +195,7 @@ func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []strin
 			resolved = append(resolved, ResolvedTemplate{
 				TemplateAsset: asset,
 				Source:        "config",
-				Path:          filepath.Join(configTemplatesDir(configDir), spec.Filename),
+				Path:          filepath.Join(configTemplatesDir(configDir), asset.Filename),
 			})
 			continue
 		}
@@ -220,6 +231,9 @@ func ExportBundle(configDir string) (Bundle, []string, error) {
 
 // ImportBundle writes template assets into config storage.
 func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
+	if bundle.SchemaVersion != "" && bundle.SchemaVersion != DefaultSchemaVersion {
+		return nil, fmt.Errorf("unsupported template bundle schema version %q", bundle.SchemaVersion)
+	}
 	if len(bundle.Assets) == 0 {
 		return []string{"bundle did not include workflow templates; nothing imported"}, nil
 	}
@@ -247,6 +261,10 @@ func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
 			} else {
 				filename = asset.Key + ".txt"
 			}
+		}
+		filename, err := sanitizeTemplateFilename(filename)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filename for template key %q: %w", asset.Key, err)
 		}
 		if strings.TrimSpace(asset.Content) == "" {
 			warnings = append(warnings, fmt.Sprintf("skipped empty template %q", filename))
@@ -327,7 +345,12 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 		filename := spec.Filename
 		if meta.Filenames != nil {
 			if mfn := strings.TrimSpace(meta.Filenames[spec.Key]); mfn != "" {
-				filename = mfn
+				safeFilename, err := sanitizeTemplateFilename(mfn)
+				if err != nil {
+					warnings = append(warnings, fmt.Sprintf("ignoring unsafe metadata filename for %q: %v", spec.Key, err))
+				} else {
+					filename = safeFilename
+				}
 			}
 		}
 		path := filepath.Join(configTemplatesDir(configDir), filename)
@@ -427,6 +450,27 @@ func normalizeTemplateName(name string) string {
 	n = strings.TrimSuffix(n, ".txt")
 	n = strings.ReplaceAll(n, "-", "_")
 	return n
+}
+
+func sanitizeTemplateFilename(filename string) (string, error) {
+	name := strings.TrimSpace(filename)
+	if name == "" {
+		return "", errors.New("empty filename")
+	}
+	cleaned := filepath.Clean(name)
+	if filepath.IsAbs(name) || filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("absolute paths are not allowed: %q", filename)
+	}
+	if cleaned == "." || cleaned == ".." {
+		return "", fmt.Errorf("invalid path: %q", filename)
+	}
+	if filepath.Base(cleaned) != cleaned {
+		return "", fmt.Errorf("path separators are not allowed: %q", filename)
+	}
+	if strings.Contains(cleaned, "/") || strings.Contains(cleaned, `\`) {
+		return "", fmt.Errorf("path separators are not allowed: %q", filename)
+	}
+	return cleaned, nil
 }
 
 func dedupeWarnings(warnings []string) []string {

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -17,6 +17,7 @@ const (
 	DefaultSchemaVersion = "1"
 	TemplatesDirName     = "templates"
 	metadataFileName     = "metadata.json"
+	RepoLocalVersion     = "repo-local"
 )
 
 // TemplateAsset stores one workflow template body with metadata.
@@ -177,7 +178,7 @@ func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []strin
 					TemplateAsset: TemplateAsset{
 						Key:       spec.Key,
 						Filename:  spec.Filename,
-						Version:   spec.Version,
+						Version:   RepoLocalVersion,
 						UpdatedAt: time.Time{},
 						Content:   content,
 					},
@@ -259,6 +260,7 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 	}
 	warnings := make([]string, 0)
 	meta, metaErr := readMetadata(configDir)
+	metadataNeedsRepair := metaErr != nil && !errors.Is(metaErr, os.ErrNotExist)
 	if metaErr != nil {
 		if !errors.Is(metaErr, os.ErrNotExist) {
 			// Allow bundle import to repair corrupted metadata by resetting to defaults.
@@ -316,6 +318,9 @@ func ImportBundle(configDir string, bundle Bundle) (int, []string, error) {
 		meta.Updated[asset.Key] = nonZeroTime(asset.UpdatedAt, time.Now().UTC())
 		meta.Filenames[asset.Key] = filename
 		importedCount++
+	}
+	if importedCount == 0 && !metadataNeedsRepair {
+		return 0, dedupeWarnings(warnings), nil
 	}
 	meta.UpdatedAt = time.Now().UTC()
 	if err := writeMetadata(configDir, meta); err != nil {

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -343,24 +343,30 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 		return nil, fmt.Errorf("creating templates directory: %w", err)
 	}
 	now := time.Now().UTC()
+	dirty := false
 	meta, metaErr := readMetadata(configDir)
 	if metaErr != nil {
 		if !errors.Is(metaErr, os.ErrNotExist) {
 			return nil, fmt.Errorf("reading template metadata: %w", metaErr)
 		}
 		meta = metadataFile{}
+		dirty = true
 	}
 	if meta.SchemaVersion == "" {
 		meta.SchemaVersion = DefaultSchemaVersion
+		dirty = true
 	}
 	if meta.Versions == nil {
 		meta.Versions = make(map[string]string)
+		dirty = true
 	}
 	if meta.Updated == nil {
 		meta.Updated = make(map[string]time.Time)
+		dirty = true
 	}
 	if meta.Filenames == nil {
 		meta.Filenames = make(map[string]string)
+		dirty = true
 	}
 
 	written := make([]TemplateAsset, 0, len(defaultSpecs))
@@ -379,12 +385,15 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 			if content, ok, _ := readTemplateFile(path); ok && strings.TrimSpace(content) != "" {
 				if _, ok := meta.Versions[spec.Key]; !ok {
 					meta.Versions[spec.Key] = spec.Version
+					dirty = true
 				}
 				if _, ok := meta.Filenames[spec.Key]; !ok {
 					meta.Filenames[spec.Key] = filename
+					dirty = true
 				}
 				if _, ok := meta.Updated[spec.Key]; !ok {
 					meta.Updated[spec.Key] = now
+					dirty = true
 				}
 				continue
 			}
@@ -393,10 +402,15 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 				if content, ok, _ := readTemplateFile(canonicalPath); ok && strings.TrimSpace(content) != "" {
 					if _, ok := meta.Versions[spec.Key]; !ok {
 						meta.Versions[spec.Key] = spec.Version
+						dirty = true
 					}
-					meta.Filenames[spec.Key] = spec.Filename
+					if meta.Filenames[spec.Key] != spec.Filename {
+						meta.Filenames[spec.Key] = spec.Filename
+						dirty = true
+					}
 					if _, ok := meta.Updated[spec.Key]; !ok {
 						meta.Updated[spec.Key] = now
+						dirty = true
 					}
 					continue
 				}
@@ -408,6 +422,7 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 		meta.Versions[spec.Key] = spec.Version
 		meta.Updated[spec.Key] = now
 		meta.Filenames[spec.Key] = filename
+		dirty = true
 		written = append(written, TemplateAsset{
 			Key:       spec.Key,
 			Filename:  filename,
@@ -415,6 +430,9 @@ func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, erro
 			UpdatedAt: now,
 			Content:   spec.Content,
 		})
+	}
+	if !dirty {
+		return written, nil
 	}
 	meta.UpdatedAt = now
 	if err := writeMetadata(configDir, meta); err != nil {

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -443,19 +443,33 @@ func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
 				}
 			}
 		}
-		path := filepath.Join(configTemplatesDir(configDir), filename)
+		selectedFilename := filename
+		path := filepath.Join(configTemplatesDir(configDir), selectedFilename)
 		content, ok, warn := readTemplateFile(path)
 		if !ok {
 			if warn != "" {
 				warnings = append(warnings, warn)
 			} else if usedMetadataFilename {
-				warnings = append(warnings, fmt.Sprintf("template %q referenced by metadata for %q is missing; falling back", filename, spec.Key))
+				warnings = append(warnings, fmt.Sprintf("template %q referenced by metadata for %q is missing; falling back", selectedFilename, spec.Key))
 			}
+			if usedMetadataFilename {
+				canonicalPath := filepath.Join(configTemplatesDir(configDir), spec.Filename)
+				canonicalContent, canonicalOK, canonicalWarn := readTemplateFile(canonicalPath)
+				if canonicalOK {
+					content = canonicalContent
+					ok = true
+					selectedFilename = spec.Filename
+				} else if canonicalWarn != "" {
+					warnings = append(warnings, canonicalWarn)
+				}
+			}
+		}
+		if !ok {
 			continue
 		}
 		asset := TemplateAsset{
 			Key:       spec.Key,
-			Filename:  filename,
+			Filename:  selectedFilename,
 			Version:   spec.Version,
 			UpdatedAt: time.Time{},
 			Content:   content,
@@ -555,9 +569,6 @@ func sanitizeTemplateFilename(filename string) (string, error) {
 	if name == "" {
 		return "", errors.New("empty filename")
 	}
-	if strings.EqualFold(name, metadataFileName) {
-		return "", fmt.Errorf("reserved filename is not allowed: %q", filename)
-	}
 	cleaned := filepath.Clean(name)
 	if filepath.IsAbs(name) || filepath.IsAbs(cleaned) {
 		return "", fmt.Errorf("absolute paths are not allowed: %q", filename)
@@ -573,6 +584,9 @@ func sanitizeTemplateFilename(filename string) (string, error) {
 	}
 	if strings.Contains(cleaned, "/") || strings.Contains(cleaned, `\`) {
 		return "", fmt.Errorf("path separators are not allowed: %q", filename)
+	}
+	if strings.EqualFold(cleaned, metadataFileName) {
+		return "", fmt.Errorf("reserved filename is not allowed: %q", filename)
 	}
 	return cleaned, nil
 }

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -462,9 +462,15 @@ func sanitizeTemplateFilename(filename string) (string, error) {
 	if name == "" {
 		return "", errors.New("empty filename")
 	}
+	if strings.EqualFold(name, metadataFileName) {
+		return "", fmt.Errorf("reserved filename is not allowed: %q", filename)
+	}
 	cleaned := filepath.Clean(name)
 	if filepath.IsAbs(name) || filepath.IsAbs(cleaned) {
 		return "", fmt.Errorf("absolute paths are not allowed: %q", filename)
+	}
+	if filepath.VolumeName(name) != "" || filepath.VolumeName(cleaned) != "" || strings.Contains(cleaned, ":") {
+		return "", fmt.Errorf("volume-qualified paths are not allowed: %q", filename)
 	}
 	if cleaned == "." || cleaned == ".." {
 		return "", fmt.Errorf("invalid path: %q", filename)

--- a/internal/workflowtemplates/templates.go
+++ b/internal/workflowtemplates/templates.go
@@ -1,0 +1,474 @@
+package workflowtemplates
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nikolareljin/agentvault/internal/config"
+)
+
+const (
+	DefaultSchemaVersion = "1"
+	TemplatesDirName     = "templates"
+	metadataFileName     = "metadata.json"
+)
+
+// TemplateAsset stores one workflow template body with metadata.
+type TemplateAsset struct {
+	Key       string    `json:"key"`
+	Filename  string    `json:"filename"`
+	Version   string    `json:"version"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Content   string    `json:"content"`
+}
+
+// Bundle is embedded in setup export/import payloads.
+type Bundle struct {
+	SchemaVersion string          `json:"schema_version"`
+	ExportedAt    time.Time       `json:"exported_at"`
+	Assets        []TemplateAsset `json:"assets"`
+}
+
+// ResolvedTemplate describes one effective template with its source.
+type ResolvedTemplate struct {
+	TemplateAsset
+	Source string `json:"source"`
+	Path   string `json:"path,omitempty"`
+}
+
+type metadataFile struct {
+	SchemaVersion string                     `json:"schema_version"`
+	UpdatedAt     time.Time                  `json:"updated_at,omitempty"`
+	Versions      map[string]string          `json:"versions,omitempty"`
+	Updated       map[string]time.Time       `json:"updated,omitempty"`
+	Filenames     map[string]string          `json:"filenames,omitempty"`
+	Extra         map[string]json.RawMessage `json:"-"`
+}
+
+var defaultSpecs = []TemplateAsset{
+	{
+		Key:      "implement_issue",
+		Filename: "implement_issue.txt",
+		Version:  "builtin-1.0",
+		Content: `Implement Issue Template
+
+Metadata:
+- Template Version: 1.0
+- Template Type: Issue Workflow
+
+Inputs:
+- Repository path
+- Issue reference
+- Base branch
+
+Workflow:
+1. Review issue scope and acceptance criteria.
+2. Create a release branch from the selected base branch.
+3. Implement code changes.
+4. Update tests and documentation.
+5. Run validation commands.
+6. Commit, push, and open PR that references the issue.
+
+Notes:
+- Keep changes scoped to the issue.
+- Prefer clear commit messages and explicit test results.
+`,
+	},
+	{
+		Key:      "implement_pr",
+		Filename: "implement_pr.txt",
+		Version:  "builtin-1.0",
+		Content: `Implement PR Review Template
+
+Metadata:
+- Template Version: 1.0
+- Template Type: PR Review Fix Workflow
+
+Inputs:
+- Repository path
+- PR reference
+
+Workflow:
+1. Gather unresolved review comments.
+2. Implement code fixes aligned with reviewer feedback.
+3. Add or update tests for regressions.
+4. Run lint/test/build checks.
+5. Commit, push, and update PR with concise summary.
+6. Re-request review only (do not request automated code fixing).
+`,
+	},
+	{
+		Key:      "add_issue",
+		Filename: "add_issue.txt",
+		Version:  "builtin-1.0",
+		Content: `Add Issue Template
+
+Metadata:
+- Template Version: 1.0
+- Template Type: Issue Creation Workflow
+
+Inputs:
+- Repository path
+- Feature or bug description
+
+Workflow:
+1. Define problem statement and impact.
+2. Add acceptance criteria.
+3. Add implementation notes and validation approach.
+4. Create issue with a clear, actionable title.
+`,
+	},
+}
+
+// SupportedKeys returns sorted known template keys.
+func SupportedKeys() []string {
+	keys := make([]string, 0, len(defaultSpecs))
+	for _, spec := range defaultSpecs {
+		keys = append(keys, spec.Key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// FindTemplateFilename resolves a key or filename into the canonical filename.
+func FindTemplateFilename(name string) (string, bool) {
+	norm := normalizeTemplateName(name)
+	for _, spec := range defaultSpecs {
+		if norm == spec.Key || norm == spec.Filename {
+			return spec.Filename, true
+		}
+	}
+	return "", false
+}
+
+// LoadResolved loads effective templates with precedence repo-local > config > built-in.
+func LoadResolved(configDir string, repoDir string) ([]ResolvedTemplate, []string, error) {
+	assets, warnings, err := loadConfigAssets(configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	byKey := make(map[string]TemplateAsset, len(assets))
+	for _, a := range assets {
+		byKey[a.Key] = a
+	}
+
+	resolved := make([]ResolvedTemplate, 0, len(defaultSpecs))
+	for _, spec := range defaultSpecs {
+		if repoDir != "" {
+			repoPath := filepath.Join(repoDir, spec.Filename)
+			if content, ok, warn := readTemplateFile(repoPath); ok {
+				resolved = append(resolved, ResolvedTemplate{
+					TemplateAsset: TemplateAsset{
+						Key:       spec.Key,
+						Filename:  spec.Filename,
+						Version:   "repo-local",
+						UpdatedAt: time.Time{},
+						Content:   content,
+					},
+					Source: "repo-local",
+					Path:   repoPath,
+				})
+				continue
+			} else if warn != "" {
+				warnings = append(warnings, warn)
+			}
+		}
+
+		if asset, ok := byKey[spec.Key]; ok && strings.TrimSpace(asset.Content) != "" {
+			resolved = append(resolved, ResolvedTemplate{
+				TemplateAsset: asset,
+				Source:        "config",
+				Path:          filepath.Join(configTemplatesDir(configDir), spec.Filename),
+			})
+			continue
+		}
+
+		warnings = append(warnings, fmt.Sprintf("template %q missing from config storage; using built-in default", spec.Filename))
+		resolved = append(resolved, ResolvedTemplate{
+			TemplateAsset: spec,
+			Source:        "built-in",
+		})
+	}
+
+	sort.Slice(resolved, func(i, j int) bool { return resolved[i].Filename < resolved[j].Filename })
+	return resolved, dedupeWarnings(warnings), nil
+}
+
+// ExportBundle creates setup-export payload from config storage and defaults.
+func ExportBundle(configDir string) (Bundle, []string, error) {
+	assets, warnings, err := loadConfigAssets(configDir)
+	if err != nil {
+		return Bundle{}, nil, err
+	}
+	if len(assets) == 0 {
+		assets = cloneDefaults()
+		warnings = append(warnings, "no workflow templates found in config storage; exporting built-in defaults")
+	}
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Filename < assets[j].Filename })
+	return Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets:        assets,
+	}, dedupeWarnings(warnings), nil
+}
+
+// ImportBundle writes template assets into config storage.
+func ImportBundle(configDir string, bundle Bundle) ([]string, error) {
+	if len(bundle.Assets) == 0 {
+		return []string{"bundle did not include workflow templates; nothing imported"}, nil
+	}
+	if err := os.MkdirAll(configTemplatesDir(configDir), 0755); err != nil {
+		return nil, fmt.Errorf("creating templates directory: %w", err)
+	}
+	meta := metadataFile{
+		SchemaVersion: DefaultSchemaVersion,
+		UpdatedAt:     time.Now().UTC(),
+		Versions:      make(map[string]string),
+		Updated:       make(map[string]time.Time),
+		Filenames:     make(map[string]string),
+	}
+	warnings := make([]string, 0)
+	for _, asset := range bundle.Assets {
+		asset.Key = normalizeTemplateName(asset.Key)
+		if asset.Key == "" {
+			warnings = append(warnings, "skipped template with empty key")
+			continue
+		}
+		filename := asset.Filename
+		if filename == "" {
+			if def, ok := findDefaultByKey(asset.Key); ok {
+				filename = def.Filename
+			} else {
+				filename = asset.Key + ".txt"
+			}
+		}
+		if strings.TrimSpace(asset.Content) == "" {
+			warnings = append(warnings, fmt.Sprintf("skipped empty template %q", filename))
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), filename), []byte(asset.Content), 0644); err != nil {
+			return nil, fmt.Errorf("writing template %s: %w", filename, err)
+		}
+		meta.Versions[asset.Key] = firstNonEmpty(asset.Version, "imported")
+		meta.Updated[asset.Key] = nonZeroTime(asset.UpdatedAt, time.Now().UTC())
+		meta.Filenames[asset.Key] = filename
+	}
+	if err := writeMetadata(configDir, meta); err != nil {
+		return nil, err
+	}
+	return dedupeWarnings(warnings), nil
+}
+
+// RefreshConfigTemplates ensures config storage contains default templates and metadata.
+func RefreshConfigTemplates(configDir string, force bool) ([]TemplateAsset, error) {
+	templatesDir := configTemplatesDir(configDir)
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating templates directory: %w", err)
+	}
+	now := time.Now().UTC()
+	meta, _ := readMetadata(configDir)
+	if meta.SchemaVersion == "" {
+		meta.SchemaVersion = DefaultSchemaVersion
+	}
+	if meta.Versions == nil {
+		meta.Versions = make(map[string]string)
+	}
+	if meta.Updated == nil {
+		meta.Updated = make(map[string]time.Time)
+	}
+	if meta.Filenames == nil {
+		meta.Filenames = make(map[string]string)
+	}
+
+	written := make([]TemplateAsset, 0, len(defaultSpecs))
+	for _, spec := range defaultSpecs {
+		path := filepath.Join(templatesDir, spec.Filename)
+		if !force {
+			if content, ok, _ := readTemplateFile(path); ok && strings.TrimSpace(content) != "" {
+				if _, ok := meta.Versions[spec.Key]; !ok {
+					meta.Versions[spec.Key] = spec.Version
+				}
+				if _, ok := meta.Filenames[spec.Key]; !ok {
+					meta.Filenames[spec.Key] = spec.Filename
+				}
+				continue
+			}
+		}
+		if err := os.WriteFile(path, []byte(spec.Content), 0644); err != nil {
+			return nil, fmt.Errorf("writing template %s: %w", spec.Filename, err)
+		}
+		meta.Versions[spec.Key] = spec.Version
+		meta.Updated[spec.Key] = now
+		meta.Filenames[spec.Key] = spec.Filename
+		written = append(written, spec)
+	}
+	meta.UpdatedAt = now
+	if err := writeMetadata(configDir, meta); err != nil {
+		return nil, err
+	}
+	return written, nil
+}
+
+func loadConfigAssets(configDir string) ([]TemplateAsset, []string, error) {
+	meta, metaErr := readMetadata(configDir)
+	warnings := make([]string, 0)
+	if metaErr != nil && !errors.Is(metaErr, os.ErrNotExist) {
+		warnings = append(warnings, fmt.Sprintf("template metadata is invalid; using safe fallbacks (%v)", metaErr))
+	}
+
+	assets := make([]TemplateAsset, 0, len(defaultSpecs))
+	for _, spec := range defaultSpecs {
+		filename := spec.Filename
+		if meta.Filenames != nil {
+			if mfn := strings.TrimSpace(meta.Filenames[spec.Key]); mfn != "" {
+				filename = mfn
+			}
+		}
+		path := filepath.Join(configTemplatesDir(configDir), filename)
+		content, ok, warn := readTemplateFile(path)
+		if !ok {
+			if warn != "" {
+				warnings = append(warnings, warn)
+			}
+			continue
+		}
+		asset := TemplateAsset{
+			Key:       spec.Key,
+			Filename:  filename,
+			Version:   spec.Version,
+			UpdatedAt: time.Time{},
+			Content:   content,
+		}
+		if meta.Versions != nil {
+			if v := strings.TrimSpace(meta.Versions[spec.Key]); v != "" {
+				asset.Version = v
+			}
+		}
+		if meta.Updated != nil {
+			asset.UpdatedAt = meta.Updated[spec.Key]
+		}
+		assets = append(assets, asset)
+	}
+
+	return assets, dedupeWarnings(warnings), nil
+}
+
+func readTemplateFile(path string) (string, bool, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, ""
+		}
+		return "", false, fmt.Sprintf("cannot read template %q; skipping (%v)", filepath.Base(path), err)
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return "", false, fmt.Sprintf("template %q is empty; skipping", filepath.Base(path))
+	}
+	return string(data), true, ""
+}
+
+func readMetadata(configDir string) (metadataFile, error) {
+	path := filepath.Join(configTemplatesDir(configDir), metadataFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return metadataFile{}, err
+	}
+	var meta metadataFile
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return metadataFile{}, fmt.Errorf("decoding metadata: %w", err)
+	}
+	if meta.SchemaVersion == "" {
+		meta.SchemaVersion = DefaultSchemaVersion
+	}
+	return meta, nil
+}
+
+func writeMetadata(configDir string, meta metadataFile) error {
+	if err := os.MkdirAll(configTemplatesDir(configDir), 0755); err != nil {
+		return fmt.Errorf("creating templates directory: %w", err)
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding metadata: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(configTemplatesDir(configDir), metadataFileName), data, 0644); err != nil {
+		return fmt.Errorf("writing metadata: %w", err)
+	}
+	return nil
+}
+
+func cloneDefaults() []TemplateAsset {
+	cloned := make([]TemplateAsset, len(defaultSpecs))
+	copy(cloned, defaultSpecs)
+	for i := range cloned {
+		cloned[i].UpdatedAt = time.Time{}
+	}
+	return cloned
+}
+
+func findDefaultByKey(key string) (TemplateAsset, bool) {
+	for _, spec := range defaultSpecs {
+		if spec.Key == key {
+			return spec, true
+		}
+	}
+	return TemplateAsset{}, false
+}
+
+func normalizeTemplateName(name string) string {
+	n := strings.TrimSpace(strings.ToLower(name))
+	n = strings.TrimSuffix(n, ".txt")
+	n = strings.ReplaceAll(n, "-", "_")
+	return n
+}
+
+func dedupeWarnings(warnings []string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(warnings))
+	out := make([]string, 0, len(warnings))
+	for _, w := range warnings {
+		w = strings.TrimSpace(w)
+		if w == "" {
+			continue
+		}
+		if _, ok := seen[w]; ok {
+			continue
+		}
+		seen[w] = struct{}{}
+		out = append(out, w)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func nonZeroTime(value, fallback time.Time) time.Time {
+	if value.IsZero() {
+		return fallback
+	}
+	return value
+}
+
+func configTemplatesDir(configDir string) string {
+	if strings.TrimSpace(configDir) != "" {
+		return filepath.Join(configDir, TemplatesDirName)
+	}
+	return config.TemplatesDir()
+}

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -682,6 +682,47 @@ func TestExportBundleAvoidsDuplicateResolvedFilenames(t *testing.T) {
 	}
 }
 
+func TestLoadResolvedDoesNotAddGenericMissingWarningAfterConflictWarning(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "shared.txt"), []byte("shared body\n"), 0600); err != nil {
+		t.Fatalf("WriteFile(shared): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {
+    "implement_issue": "shared.txt",
+    "implement_pr": "shared.txt"
+  }
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	_, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	conflictCount := 0
+	missingCount := 0
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `template "shared.txt" for "implement_pr" conflicts with "implement_issue"; falling back to built-in default`) {
+			conflictCount++
+		}
+		if strings.Contains(warningText, `template "implement_pr.txt" missing from config storage; using built-in default`) {
+			missingCount++
+		}
+	}
+	if conflictCount != 1 {
+		t.Fatalf("conflict warning count = %d, want 1", conflictCount)
+	}
+	if missingCount != 0 {
+		t.Fatalf("missing warning count = %d, want 0 when conflict warning exists", missingCount)
+	}
+}
+
 func TestRefreshConfigTemplatesBackfillsUpdatedMetadata(t *testing.T) {
 	cfgDir := t.TempDir()
 	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -628,6 +628,55 @@ func TestRefreshConfigTemplatesBackfillsUpdatedMetadata(t *testing.T) {
 	}
 }
 
+func TestRefreshConfigTemplatesPreservesMetadataSelectedFilenameWithoutForce(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	customName := "custom-issue-template.txt"
+	customContent := "custom issue body\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, customName), []byte(customContent), 0600); err != nil {
+		t.Fatalf("WriteFile(custom): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "versions": {"implement_issue": "custom-v1"},
+  "updated": {"implement_issue": "2026-03-09T00:00:00Z"},
+  "filenames": {"implement_issue": "`+customName+`"}
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	written, err := RefreshConfigTemplates(cfgDir, false)
+	if err != nil {
+		t.Fatalf("RefreshConfigTemplates(force=false) error = %v", err)
+	}
+	foundCustomRewrite := false
+	for _, asset := range written {
+		if asset.Key == "implement_issue" {
+			foundCustomRewrite = true
+		}
+	}
+	if foundCustomRewrite {
+		t.Fatalf("RefreshConfigTemplates(force=false) should not rewrite existing metadata-selected file")
+	}
+
+	meta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata() error = %v", err)
+	}
+	if meta.Filenames["implement_issue"] != customName {
+		t.Fatalf("metadata filename = %q, want %q", meta.Filenames["implement_issue"], customName)
+	}
+	content, err := os.ReadFile(filepath.Join(cfgDir, TemplatesDirName, customName))
+	if err != nil {
+		t.Fatalf("ReadFile(custom): %v", err)
+	}
+	if string(content) != customContent {
+		t.Fatalf("custom content changed unexpectedly")
+	}
+}
+
 func TestImportBundlePreservesMetadataForUntouchedKeys(t *testing.T) {
 	cfgDir := t.TempDir()
 	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -259,6 +259,65 @@ func TestImportBundleRejectsUnsupportedSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestImportBundleRepairsInvalidExistingMetadata(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte("{invalid json"), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v2", Content: "fixed content\n"},
+		},
+	}
+
+	imported, warnings, err := ImportBundle(cfgDir, bundle)
+	if err != nil {
+		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("ImportBundle() imported count = %d, want 1", imported)
+	}
+	var hasRepairWarning bool
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, "existing template metadata invalid; resetting metadata defaults") {
+			hasRepairWarning = true
+		}
+	}
+	if !hasRepairWarning {
+		t.Fatalf("expected metadata repair warning, got %v", warnings)
+	}
+	meta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata() error = %v", err)
+	}
+	if meta.Versions["implement_issue"] != "v2" {
+		t.Fatalf("metadata version = %q, want v2", meta.Versions["implement_issue"])
+	}
+}
+
+func TestRefreshConfigTemplatesErrorsOnInvalidMetadata(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte("{invalid json"), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	_, err := RefreshConfigTemplates(cfgDir, false)
+	if err == nil {
+		t.Fatalf("RefreshConfigTemplates() expected metadata error")
+	}
+	if !strings.Contains(err.Error(), "reading template metadata") {
+		t.Fatalf("RefreshConfigTemplates() err = %v, want metadata read context", err)
+	}
+}
+
 func TestLoadResolvedUsesSanitizedMetadataFilename(t *testing.T) {
 	cfgDir := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -203,19 +203,31 @@ func TestFindTemplateFilenameAcceptsFilenameInput(t *testing.T) {
 
 func TestImportBundleRejectsUnsafeFilename(t *testing.T) {
 	cfgDir := t.TempDir()
-	bundle := Bundle{
-		SchemaVersion: DefaultSchemaVersion,
-		ExportedAt:    time.Now().UTC(),
-		Assets: []TemplateAsset{
-			{Key: "implement_issue", Filename: "../escape.txt", Version: "v1", Content: "x\n"},
-		},
+	testCases := []struct {
+		name     string
+		filename string
+	}{
+		{name: "path-traversal", filename: "../escape.txt"},
+		{name: "reserved-metadata", filename: "metadata.json"},
+		{name: "windows-volume", filename: "C:escape.txt"},
 	}
-	_, err := ImportBundle(cfgDir, bundle)
-	if err == nil {
-		t.Fatalf("ImportBundle() expected unsafe filename error")
-	}
-	if !strings.Contains(err.Error(), "invalid filename") {
-		t.Fatalf("ImportBundle() err = %v, want invalid filename", err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := Bundle{
+				SchemaVersion: DefaultSchemaVersion,
+				ExportedAt:    time.Now().UTC(),
+				Assets: []TemplateAsset{
+					{Key: "implement_issue", Filename: tc.filename, Version: "v1", Content: "x\n"},
+				},
+			}
+			_, err := ImportBundle(cfgDir, bundle)
+			if err == nil {
+				t.Fatalf("ImportBundle() expected unsafe filename error for %q", tc.filename)
+			}
+			if !strings.Contains(err.Error(), "invalid filename") {
+				t.Fatalf("ImportBundle() err = %v, want invalid filename", err)
+			}
+		})
 	}
 }
 

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -642,6 +642,46 @@ func TestExportBundleIncludesMissingDefaults(t *testing.T) {
 	}
 }
 
+func TestExportBundleAvoidsDuplicateResolvedFilenames(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "shared.txt"), []byte("shared body\n"), 0600); err != nil {
+		t.Fatalf("WriteFile(shared): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {
+    "implement_issue": "shared.txt",
+    "implement_pr": "shared.txt"
+  }
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	bundle, warnings, err := ExportBundle(cfgDir)
+	if err != nil {
+		t.Fatalf("ExportBundle() error = %v", err)
+	}
+	seen := make(map[string]string, len(bundle.Assets))
+	for _, asset := range bundle.Assets {
+		if existingKey, exists := seen[asset.Filename]; exists {
+			t.Fatalf("duplicate exported filename %q for keys %q and %q", asset.Filename, existingKey, asset.Key)
+		}
+		seen[asset.Filename] = asset.Key
+	}
+	var hasConflictWarning bool
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `conflicts with`) {
+			hasConflictWarning = true
+		}
+	}
+	if !hasConflictWarning {
+		t.Fatalf("expected duplicate filename conflict warning, got %v", warnings)
+	}
+}
+
 func TestRefreshConfigTemplatesBackfillsUpdatedMetadata(t *testing.T) {
 	cfgDir := t.TempDir()
 	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -248,6 +248,8 @@ func TestImportBundleRejectsUnsafeFilename(t *testing.T) {
 	}{
 		{name: "path-traversal", filename: "../escape.txt"},
 		{name: "reserved-metadata", filename: "metadata.json"},
+		{name: "reserved-metadata-dot-prefix", filename: "./metadata.json"},
+		{name: "reserved-metadata-collapsed", filename: "foo/../metadata.json"},
 		{name: "windows-volume", filename: "C:escape.txt"},
 	}
 	for _, tc := range testCases {
@@ -471,6 +473,54 @@ func TestLoadResolvedWarnsOnMissingMetadataSelectedFilename(t *testing.T) {
 		t.Fatalf("LoadResolved() error = %v", err)
 	}
 
+	var hasMissingMetadataWarning bool
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `template "custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back`) {
+			hasMissingMetadataWarning = true
+		}
+	}
+	if !hasMissingMetadataWarning {
+		t.Fatalf("expected missing metadata-selected filename warning, got %v", warnings)
+	}
+}
+
+func TestLoadResolvedFallsBackToCanonicalConfigFileWhenMetadataFileMissing(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	canonicalContent := "canonical issue body\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt"), []byte(canonicalContent), 0600); err != nil {
+		t.Fatalf("WriteFile(canonical): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_issue": "custom-issue-template.txt"}
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	resolved, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	var issue *ResolvedTemplate
+	for i := range resolved {
+		if resolved[i].Key == "implement_issue" {
+			issue = &resolved[i]
+			break
+		}
+	}
+	if issue == nil {
+		t.Fatalf("implement_issue template not resolved")
+	}
+	if issue.Filename != "implement_issue.txt" {
+		t.Fatalf("Filename = %q, want canonical fallback", issue.Filename)
+	}
+	if strings.TrimSpace(issue.Content) != strings.TrimSpace(canonicalContent) {
+		t.Fatalf("content mismatch after canonical fallback")
+	}
 	var hasMissingMetadataWarning bool
 	for _, warningText := range warnings {
 		if strings.Contains(warningText, `template "custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back`) {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -475,7 +475,7 @@ func TestLoadResolvedWarnsOnMissingMetadataSelectedFilename(t *testing.T) {
 
 	var hasMissingMetadataWarning bool
 	for _, warningText := range warnings {
-		if strings.Contains(warningText, `template "custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back`) {
+		if strings.Contains(warningText, `custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back to built-in default template`) {
 			hasMissingMetadataWarning = true
 		}
 	}
@@ -523,7 +523,7 @@ func TestLoadResolvedFallsBackToCanonicalConfigFileWhenMetadataFileMissing(t *te
 	}
 	var hasMissingMetadataWarning bool
 	for _, warningText := range warnings {
-		if strings.Contains(warningText, `template "custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back`) {
+		if strings.Contains(warningText, `custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back to canonical config template "implement_issue.txt"`) {
 			hasMissingMetadataWarning = true
 		}
 	}
@@ -549,7 +549,7 @@ func TestLoadResolvedDoesNotDuplicateFallbackWarning(t *testing.T) {
 	emptyCount := 0
 	missingCount := 0
 	for _, warningText := range warnings {
-		if strings.Contains(warningText, `template "implement_issue.txt" is empty; skipping`) {
+		if strings.Contains(warningText, `/templates/implement_issue.txt" is empty; skipping`) {
 			emptyCount++
 		}
 		if strings.Contains(warningText, `template "implement_issue.txt" missing from config storage; using built-in default`) {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -541,3 +541,22 @@ func TestImportBundlePreservesMetadataForUntouchedKeys(t *testing.T) {
 		t.Fatalf("implement_pr updated timestamp changed unexpectedly: %v -> %v", originalPRUpdated, afterMeta.Updated["implement_pr"])
 	}
 }
+
+func TestImportBundleRejectsDuplicateResolvedFilenames(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "shared.txt", Version: "v1", Content: "issue\n"},
+			{Key: "implement_pr", Filename: "shared.txt", Version: "v1", Content: "pr\n"},
+		},
+	}
+	_, _, err := ImportBundle(cfgDir, bundle)
+	if err == nil {
+		t.Fatalf("ImportBundle() expected duplicate filename error")
+	}
+	if !strings.Contains(err.Error(), "duplicate template filename") {
+		t.Fatalf("ImportBundle() err = %v, want duplicate template filename", err)
+	}
+}

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -364,6 +364,47 @@ func TestLoadResolvedDoesNotDuplicateFallbackWarning(t *testing.T) {
 	}
 }
 
+func TestLoadResolvedKeepsFallbackWarningAfterUnsafeMetadataWarning(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	// Remove canonical file so built-in fallback is required.
+	if err := os.Remove(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt")); err != nil {
+		t.Fatalf("Remove(canonical template): %v", err)
+	}
+	// Add unsafe metadata filename to trigger metadata warning for same key.
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_issue": "../unsafe.txt"}
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	_, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+
+	var hasUnsafeMetaWarning bool
+	var hasFallbackMissingWarning bool
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `ignoring unsafe metadata filename for "implement_issue"`) {
+			hasUnsafeMetaWarning = true
+		}
+		if strings.Contains(warningText, `template "implement_issue.txt" missing from config storage; using built-in default`) {
+			hasFallbackMissingWarning = true
+		}
+	}
+	if !hasUnsafeMetaWarning {
+		t.Fatalf("expected unsafe metadata warning")
+	}
+	if !hasFallbackMissingWarning {
+		t.Fatalf("expected missing fallback warning even when unsafe metadata warning exists")
+	}
+}
+
 func TestExportBundleIncludesMissingDefaults(t *testing.T) {
 	cfgDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0700); err != nil {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -549,7 +549,7 @@ func TestLoadResolvedDoesNotDuplicateFallbackWarning(t *testing.T) {
 	emptyCount := 0
 	missingCount := 0
 	for _, warningText := range warnings {
-		if strings.Contains(warningText, `/templates/implement_issue.txt" is empty; skipping`) {
+		if strings.Contains(warningText, `implement_issue.txt" is empty; skipping`) {
 			emptyCount++
 		}
 		if strings.Contains(warningText, `template "implement_issue.txt" missing from config storage; using built-in default`) {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -174,6 +174,7 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 		Assets: []TemplateAsset{
 			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "valid\n"},
 			{Key: "implement_pr", Filename: "implement_pr.txt", Version: "v1", Content: "\n"},
+			{Key: "custom_template", Filename: "custom_template.txt", Version: "v1", Content: "custom\n"},
 		},
 	}
 	warnings, err := ImportBundle(cfgDir, bundle)
@@ -188,6 +189,9 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, "implement_pr.txt")); !os.IsNotExist(err) {
 		t.Fatalf("implement_pr.txt should not exist, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, "custom_template.txt")); !os.IsNotExist(err) {
+		t.Fatalf("custom_template.txt should not exist, err=%v", err)
 	}
 }
 
@@ -439,5 +443,41 @@ func TestExportBundleIncludesMissingDefaults(t *testing.T) {
 	}
 	if !foundMissingDefaultWarning {
 		t.Fatalf("expected warning about exporting built-in default")
+	}
+}
+
+func TestRefreshConfigTemplatesBackfillsUpdatedMetadata(t *testing.T) {
+	cfgDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates(force=true) error = %v", err)
+	}
+	// Remove updated metadata while keeping template files in place.
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "versions": {
+    "implement_issue": "builtin-1.0",
+    "implement_pr": "builtin-1.0",
+    "add_issue": "builtin-1.0"
+  },
+  "filenames": {
+    "implement_issue": "implement_issue.txt",
+    "implement_pr": "implement_pr.txt",
+    "add_issue": "add_issue.txt"
+  }
+}`), 0600); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+	if _, err := RefreshConfigTemplates(cfgDir, false); err != nil {
+		t.Fatalf("RefreshConfigTemplates(force=false) error = %v", err)
+	}
+	meta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata() error = %v", err)
+	}
+	for _, key := range []string{"implement_issue", "implement_pr", "add_issue"} {
+		ts := meta.Updated[key]
+		if ts.IsZero() {
+			t.Fatalf("meta.Updated[%q] should be backfilled", key)
+		}
 	}
 }

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -133,9 +133,12 @@ func TestExportImportRoundTripPreservesTemplateMetadata(t *testing.T) {
 		t.Fatalf("bundle assets empty")
 	}
 
-	importWarnings, err := ImportBundle(dstCfg, bundle)
+	imported, importWarnings, err := ImportBundle(dstCfg, bundle)
 	if err != nil {
 		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if imported == 0 {
+		t.Fatalf("ImportBundle() imported count = 0, want > 0")
 	}
 	if len(importWarnings) != 0 {
 		t.Fatalf("ImportBundle() warnings = %v, want none", importWarnings)
@@ -177,9 +180,12 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 			{Key: "custom_template", Filename: "custom_template.txt", Version: "v1", Content: "custom\n"},
 		},
 	}
-	warnings, err := ImportBundle(cfgDir, bundle)
+	imported, warnings, err := ImportBundle(cfgDir, bundle)
 	if err != nil {
 		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("ImportBundle() imported count = %d, want 1", imported)
 	}
 	if len(warnings) == 0 {
 		t.Fatalf("expected warnings for empty asset")
@@ -224,7 +230,7 @@ func TestImportBundleRejectsUnsafeFilename(t *testing.T) {
 					{Key: "implement_issue", Filename: tc.filename, Version: "v1", Content: "x\n"},
 				},
 			}
-			_, err := ImportBundle(cfgDir, bundle)
+			_, _, err := ImportBundle(cfgDir, bundle)
 			if err == nil {
 				t.Fatalf("ImportBundle() expected unsafe filename error for %q", tc.filename)
 			}
@@ -244,7 +250,7 @@ func TestImportBundleRejectsUnsupportedSchemaVersion(t *testing.T) {
 			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "x\n"},
 		},
 	}
-	_, err := ImportBundle(cfgDir, bundle)
+	_, _, err := ImportBundle(cfgDir, bundle)
 	if err == nil {
 		t.Fatalf("ImportBundle() expected schema version error")
 	}
@@ -479,5 +485,59 @@ func TestRefreshConfigTemplatesBackfillsUpdatedMetadata(t *testing.T) {
 		if ts.IsZero() {
 			t.Fatalf("meta.Updated[%q] should be backfilled", key)
 		}
+	}
+}
+
+func TestImportBundlePreservesMetadataForUntouchedKeys(t *testing.T) {
+	cfgDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	beforeMeta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata(before) error = %v", err)
+	}
+	originalPRFilename := beforeMeta.Filenames["implement_pr"]
+	originalPRVersion := beforeMeta.Versions["implement_pr"]
+	originalPRUpdated := beforeMeta.Updated["implement_pr"]
+	if originalPRFilename == "" || originalPRVersion == "" || originalPRUpdated.IsZero() {
+		t.Fatalf("expected initialized metadata for implement_pr")
+	}
+
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{
+				Key:      "implement_issue",
+				Filename: "implement_issue.txt",
+				Version:  "imported-v2",
+				Content:  "updated issue body\n",
+			},
+		},
+	}
+	imported, warnings, err := ImportBundle(cfgDir, bundle)
+	if err != nil {
+		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("ImportBundle() imported count = %d, want 1", imported)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ImportBundle() warnings = %v, want none", warnings)
+	}
+
+	afterMeta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata(after) error = %v", err)
+	}
+	if afterMeta.Filenames["implement_pr"] != originalPRFilename {
+		t.Fatalf("implement_pr filename changed unexpectedly: %q -> %q", originalPRFilename, afterMeta.Filenames["implement_pr"])
+	}
+	if afterMeta.Versions["implement_pr"] != originalPRVersion {
+		t.Fatalf("implement_pr version changed unexpectedly: %q -> %q", originalPRVersion, afterMeta.Versions["implement_pr"])
+	}
+	if !afterMeta.Updated["implement_pr"].Equal(originalPRUpdated) {
+		t.Fatalf("implement_pr updated timestamp changed unexpectedly: %v -> %v", originalPRUpdated, afterMeta.Updated["implement_pr"])
 	}
 }

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -46,6 +46,9 @@ func TestLoadResolvedPrecedence(t *testing.T) {
 	if gotIssue.Source != "repo-local" {
 		t.Fatalf("implement_issue source = %q, want repo-local", gotIssue.Source)
 	}
+	if gotIssue.Version != RepoLocalVersion {
+		t.Fatalf("implement_issue version = %q, want %q", gotIssue.Version, RepoLocalVersion)
+	}
 	if strings.TrimSpace(gotIssue.Content) != strings.TrimSpace(repoOverride) {
 		t.Fatalf("implement_issue content mismatch")
 	}
@@ -198,6 +201,32 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, "custom_template.txt")); !os.IsNotExist(err) {
 		t.Fatalf("custom_template.txt should not exist, err=%v", err)
+	}
+}
+
+func TestImportBundleNoOpDoesNotWriteMetadata(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "\n"},
+			{Key: "unsupported", Filename: "unsupported.txt", Version: "v1", Content: "x\n"},
+		},
+	}
+
+	imported, warnings, err := ImportBundle(cfgDir, bundle)
+	if err != nil {
+		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if imported != 0 {
+		t.Fatalf("ImportBundle() imported count = %d, want 0", imported)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected warnings for no-op import")
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, metadataFileName)); !os.IsNotExist(err) {
+		t.Fatalf("metadata.json should not exist after no-op import, err=%v", err)
 	}
 }
 

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -331,3 +331,72 @@ func TestLoadResolvedIgnoresUnsafeMetadataFilename(t *testing.T) {
 		t.Fatalf("expected warning for unsafe metadata filename")
 	}
 }
+
+func TestLoadResolvedDoesNotDuplicateFallbackWarning(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt"), []byte("\n"), 0600); err != nil {
+		t.Fatalf("WriteFile(empty): %v", err)
+	}
+
+	_, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	emptyCount := 0
+	missingCount := 0
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `template "implement_issue.txt" is empty; skipping`) {
+			emptyCount++
+		}
+		if strings.Contains(warningText, `template "implement_issue.txt" missing from config storage; using built-in default`) {
+			missingCount++
+		}
+	}
+	if emptyCount != 1 {
+		t.Fatalf("empty warning count = %d, want 1", emptyCount)
+	}
+	if missingCount != 0 {
+		t.Fatalf("missing warning count = %d, want 0 when specific warning exists", missingCount)
+	}
+}
+
+func TestExportBundleIncludesMissingDefaults(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt"), []byte("issue-only\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	bundle, warnings, err := ExportBundle(cfgDir)
+	if err != nil {
+		t.Fatalf("ExportBundle() error = %v", err)
+	}
+	byKey := make(map[string]TemplateAsset, len(bundle.Assets))
+	for _, asset := range bundle.Assets {
+		byKey[asset.Key] = asset
+	}
+	for _, key := range []string{"implement_issue", "implement_pr", "add_issue"} {
+		if _, ok := byKey[key]; !ok {
+			t.Fatalf("missing key %q in exported bundle", key)
+		}
+	}
+	if strings.TrimSpace(byKey["implement_issue"].Content) != "issue-only" {
+		t.Fatalf("implement_issue content mismatch")
+	}
+	foundMissingDefaultWarning := false
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, "exporting built-in default") {
+			foundMissingDefaultWarning = true
+			break
+		}
+	}
+	if !foundMissingDefaultWarning {
+		t.Fatalf("expected warning about exporting built-in default")
+	}
+}

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -190,3 +190,122 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 		t.Fatalf("implement_pr.txt should not exist, err=%v", err)
 	}
 }
+
+func TestImportBundleRejectsUnsafeFilename(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "../escape.txt", Version: "v1", Content: "x\n"},
+		},
+	}
+	_, err := ImportBundle(cfgDir, bundle)
+	if err == nil {
+		t.Fatalf("ImportBundle() expected unsafe filename error")
+	}
+	if !strings.Contains(err.Error(), "invalid filename") {
+		t.Fatalf("ImportBundle() err = %v, want invalid filename", err)
+	}
+}
+
+func TestImportBundleRejectsUnsupportedSchemaVersion(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: "99",
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "x\n"},
+		},
+	}
+	_, err := ImportBundle(cfgDir, bundle)
+	if err == nil {
+		t.Fatalf("ImportBundle() expected schema version error")
+	}
+	if !strings.Contains(err.Error(), "unsupported template bundle schema version") {
+		t.Fatalf("ImportBundle() err = %v, want schema version error", err)
+	}
+}
+
+func TestLoadResolvedUsesSanitizedMetadataFilename(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+
+	customName := "custom-pr-template.txt"
+	customContent := "custom pr template\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, customName), []byte(customContent), 0644); err != nil {
+		t.Fatalf("WriteFile(custom template): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_pr": "`+customName+`"}
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	resolved, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	var matched *ResolvedTemplate
+	for i := range resolved {
+		if resolved[i].Key == "implement_pr" {
+			matched = &resolved[i]
+			break
+		}
+	}
+	if matched == nil {
+		t.Fatalf("implement_pr template not resolved")
+	}
+	if matched.Filename != customName {
+		t.Fatalf("Filename = %q, want %q", matched.Filename, customName)
+	}
+	wantPath := filepath.Join(cfgDir, TemplatesDirName, customName)
+	if matched.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", matched.Path, wantPath)
+	}
+	if strings.TrimSpace(matched.Content) != strings.TrimSpace(customContent) {
+		t.Fatalf("content mismatch")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+}
+
+func TestLoadResolvedIgnoresUnsafeMetadataFilename(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_issue": "../leak.txt"}
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	resolved, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	var issue ResolvedTemplate
+	for _, item := range resolved {
+		if item.Key == "implement_issue" {
+			issue = item
+			break
+		}
+	}
+	if issue.Filename != "implement_issue.txt" {
+		t.Fatalf("Filename = %q, want canonical fallback", issue.Filename)
+	}
+	if issue.Path != filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt") {
+		t.Fatalf("Path = %q, want canonical path", issue.Path)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected warning for unsafe metadata filename")
+	}
+}

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -808,6 +808,38 @@ func TestRefreshConfigTemplatesPreservesMetadataSelectedFilenameWithoutForce(t *
 	}
 }
 
+func TestRefreshConfigTemplatesDoesNotRewriteMetadataWhenUnchanged(t *testing.T) {
+	cfgDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates(force=true) error = %v", err)
+	}
+	beforeMeta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata(before) error = %v", err)
+	}
+	if beforeMeta.UpdatedAt.IsZero() {
+		t.Fatalf("expected non-zero UpdatedAt after initial refresh")
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	written, err := RefreshConfigTemplates(cfgDir, false)
+	if err != nil {
+		t.Fatalf("RefreshConfigTemplates(force=false) error = %v", err)
+	}
+	if len(written) != 0 {
+		t.Fatalf("RefreshConfigTemplates(force=false) wrote %d templates, want 0", len(written))
+	}
+
+	afterMeta, err := readMetadata(cfgDir)
+	if err != nil {
+		t.Fatalf("readMetadata(after) error = %v", err)
+	}
+	if !afterMeta.UpdatedAt.Equal(beforeMeta.UpdatedAt) {
+		t.Fatalf("UpdatedAt changed unexpectedly: %v -> %v", beforeMeta.UpdatedAt, afterMeta.UpdatedAt)
+	}
+}
+
 func TestImportBundlePreservesMetadataForUntouchedKeys(t *testing.T) {
 	cfgDir := t.TempDir()
 	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -191,6 +191,16 @@ func TestImportBundleSkipsEmptyAssets(t *testing.T) {
 	}
 }
 
+func TestFindTemplateFilenameAcceptsFilenameInput(t *testing.T) {
+	got, ok := FindTemplateFilename("implement_issue.txt")
+	if !ok {
+		t.Fatalf("FindTemplateFilename() should resolve canonical filename input")
+	}
+	if got != "implement_issue.txt" {
+		t.Fatalf("FindTemplateFilename() = %q, want implement_issue.txt", got)
+	}
+}
+
 func TestImportBundleRejectsUnsafeFilename(t *testing.T) {
 	cfgDir := t.TempDir()
 	bundle := Bundle{

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -288,6 +288,26 @@ func TestImportBundleRejectsUnsupportedSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestImportBundleRejectsDuplicateKeys(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "first\n"},
+			{Key: "implement_issue", Filename: "implement_issue-copy.txt", Version: "v2", Content: "second\n"},
+		},
+	}
+
+	_, _, err := ImportBundle(cfgDir, bundle)
+	if err == nil {
+		t.Fatalf("ImportBundle() expected duplicate key error")
+	}
+	if !strings.Contains(err.Error(), "duplicate template key") {
+		t.Fatalf("ImportBundle() err = %v, want duplicate template key", err)
+	}
+}
+
 func TestImportBundleRepairsInvalidExistingMetadata(t *testing.T) {
 	cfgDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0755); err != nil {
@@ -427,6 +447,38 @@ func TestLoadResolvedIgnoresUnsafeMetadataFilename(t *testing.T) {
 	}
 	if len(warnings) == 0 {
 		t.Fatalf("expected warning for unsafe metadata filename")
+	}
+}
+
+func TestLoadResolvedWarnsOnMissingMetadataSelectedFilename(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if _, err := RefreshConfigTemplates(cfgDir, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	if err := os.Remove(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt")); err != nil {
+		t.Fatalf("Remove(canonical template): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "filenames": {"implement_issue": "custom-issue-template.txt"}
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	_, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+
+	var hasMissingMetadataWarning bool
+	for _, warningText := range warnings {
+		if strings.Contains(warningText, `template "custom-issue-template.txt" referenced by metadata for "implement_issue" is missing; falling back`) {
+			hasMissingMetadataWarning = true
+		}
+	}
+	if !hasMissingMetadataWarning {
+		t.Fatalf("expected missing metadata-selected filename warning, got %v", warnings)
 	}
 }
 

--- a/internal/workflowtemplates/templates_test.go
+++ b/internal/workflowtemplates/templates_test.go
@@ -1,0 +1,192 @@
+package workflowtemplates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadResolvedPrecedence(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+
+	written, err := RefreshConfigTemplates(cfgDir, false)
+	if err != nil {
+		t.Fatalf("RefreshConfigTemplates() error = %v", err)
+	}
+	if len(written) == 0 {
+		t.Fatalf("RefreshConfigTemplates() wrote no templates")
+	}
+
+	repoOverride := "repo override content\n"
+	if err := os.WriteFile(filepath.Join(repoDir, "implement_issue.txt"), []byte(repoOverride), 0644); err != nil {
+		t.Fatalf("WriteFile(repo override): %v", err)
+	}
+	configOverride := "config override content\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "implement_pr.txt"), []byte(configOverride), 0644); err != nil {
+		t.Fatalf("WriteFile(config override): %v", err)
+	}
+
+	resolved, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	if len(resolved) != len(defaultSpecs) {
+		t.Fatalf("LoadResolved() len = %d, want %d", len(resolved), len(defaultSpecs))
+	}
+
+	byFilename := map[string]ResolvedTemplate{}
+	for _, item := range resolved {
+		byFilename[item.Filename] = item
+	}
+
+	gotIssue := byFilename["implement_issue.txt"]
+	if gotIssue.Source != "repo-local" {
+		t.Fatalf("implement_issue source = %q, want repo-local", gotIssue.Source)
+	}
+	if strings.TrimSpace(gotIssue.Content) != strings.TrimSpace(repoOverride) {
+		t.Fatalf("implement_issue content mismatch")
+	}
+
+	gotPR := byFilename["implement_pr.txt"]
+	if gotPR.Source != "config" {
+		t.Fatalf("implement_pr source = %q, want config", gotPR.Source)
+	}
+	if strings.TrimSpace(gotPR.Content) != strings.TrimSpace(configOverride) {
+		t.Fatalf("implement_pr content mismatch")
+	}
+
+	gotAdd := byFilename["add_issue.txt"]
+	if gotAdd.Source != "config" {
+		t.Fatalf("add_issue source = %q, want config", gotAdd.Source)
+	}
+	if strings.TrimSpace(gotAdd.Content) == "" {
+		t.Fatalf("add_issue content should not be empty")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("LoadResolved() warnings = %v, want none", warnings)
+	}
+}
+
+func TestLoadResolvedFallbackWarnings(t *testing.T) {
+	cfgDir := t.TempDir()
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, TemplatesDirName), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt"), []byte("\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(empty): %v", err)
+	}
+
+	resolved, warnings, err := LoadResolved(cfgDir, repoDir)
+	if err != nil {
+		t.Fatalf("LoadResolved() error = %v", err)
+	}
+	if len(resolved) != len(defaultSpecs) {
+		t.Fatalf("resolved len = %d, want %d", len(resolved), len(defaultSpecs))
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected fallback warnings, got none")
+	}
+	for _, item := range resolved {
+		if item.Source == "config" {
+			continue
+		}
+		if item.Source != "built-in" {
+			t.Fatalf("unexpected source %q", item.Source)
+		}
+	}
+}
+
+func TestExportImportRoundTripPreservesTemplateMetadata(t *testing.T) {
+	srcCfg := t.TempDir()
+	dstCfg := t.TempDir()
+
+	if _, err := RefreshConfigTemplates(srcCfg, true); err != nil {
+		t.Fatalf("RefreshConfigTemplates(src): %v", err)
+	}
+
+	customContent := "custom workflow body\n"
+	customVersion := "custom-2026.03.08"
+	if err := os.WriteFile(filepath.Join(srcCfg, TemplatesDirName, "implement_issue.txt"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("WriteFile(custom): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcCfg, TemplatesDirName, metadataFileName), []byte(`{
+  "schema_version": "1",
+  "versions": {"implement_issue": "`+customVersion+`"},
+  "updated": {"implement_issue": "2026-03-08T12:00:00Z"},
+  "filenames": {"implement_issue": "implement_issue.txt"}
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(metadata): %v", err)
+	}
+
+	bundle, warnings, err := ExportBundle(srcCfg)
+	if err != nil {
+		t.Fatalf("ExportBundle() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ExportBundle() warnings = %v, want none", warnings)
+	}
+	if len(bundle.Assets) == 0 {
+		t.Fatalf("bundle assets empty")
+	}
+
+	importWarnings, err := ImportBundle(dstCfg, bundle)
+	if err != nil {
+		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if len(importWarnings) != 0 {
+		t.Fatalf("ImportBundle() warnings = %v, want none", importWarnings)
+	}
+
+	dstBundle, _, err := ExportBundle(dstCfg)
+	if err != nil {
+		t.Fatalf("ExportBundle(dst) error = %v", err)
+	}
+	var found bool
+	for _, asset := range dstBundle.Assets {
+		if asset.Key != "implement_issue" {
+			continue
+		}
+		found = true
+		if strings.TrimSpace(asset.Content) != strings.TrimSpace(customContent) {
+			t.Fatalf("content mismatch after round trip")
+		}
+		if asset.Version != customVersion {
+			t.Fatalf("version = %q, want %q", asset.Version, customVersion)
+		}
+		if asset.UpdatedAt.IsZero() {
+			t.Fatalf("updated_at should be preserved/non-zero")
+		}
+	}
+	if !found {
+		t.Fatalf("implement_issue not found after round trip")
+	}
+}
+
+func TestImportBundleSkipsEmptyAssets(t *testing.T) {
+	cfgDir := t.TempDir()
+	bundle := Bundle{
+		SchemaVersion: DefaultSchemaVersion,
+		ExportedAt:    time.Now().UTC(),
+		Assets: []TemplateAsset{
+			{Key: "implement_issue", Filename: "implement_issue.txt", Version: "v1", Content: "valid\n"},
+			{Key: "implement_pr", Filename: "implement_pr.txt", Version: "v1", Content: "\n"},
+		},
+	}
+	warnings, err := ImportBundle(cfgDir, bundle)
+	if err != nil {
+		t.Fatalf("ImportBundle() error = %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected warnings for empty asset")
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, "implement_issue.txt")); err != nil {
+		t.Fatalf("expected implement_issue.txt: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, TemplatesDirName, "implement_pr.txt")); !os.IsNotExist(err) {
+		t.Fatalf("implement_pr.txt should not exist, err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add workflow template management with explicit precedence: repo-local -> config storage -> built-in fallback
- add `agentvault templates` commands (`list`, `show`, `refresh`)
- include workflow templates + metadata in `setup export/import/show` bundles
- add fallback warnings and import validation for missing/corrupt/empty template assets
- add tests for precedence and export/import metadata round-trip

## Validation
- go test ./...

Closes #18