### PR TITLE
feat(serve): POST /api/v1/prompt, with agentic runners refused by default

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -291,7 +291,7 @@ func runPrompt(cmd *cobra.Command, args []string) error {
 	if decision != nil && !jsonOut {
 		printRoutingDecision(cmd.ErrOrStderr(), a, target, decision)
 	}
-	result, execErr := executePromptTarget(target, a, effectivePrompt, timeout, executionWorkspace.Path, stream, cmd.OutOrStdout(), cmd.ErrOrStderr())
+	result, execErr := executePromptTarget(cmd.Context(), target, a, effectivePrompt, timeout, executionWorkspace.Path, stream, cmd.OutOrStdout(), cmd.ErrOrStderr())
 
 	// Derive the execution provider from the resolved runner so that cost attribution
 	// and history records reflect what actually ran (e.g. Claude+Ollama → ollama, free).
@@ -584,13 +584,13 @@ func executePrompt(a agent.Agent, prompt string, timeout time.Duration) (promptR
 	if err != nil {
 		return promptResult{}, err
 	}
-	return executePromptTarget(target, a, prompt, timeout, executionDir, false, os.Stdout, os.Stderr)
+	return executePromptTarget(context.Background(), target, a, prompt, timeout, executionDir, false, os.Stdout, os.Stderr)
 }
 
-func executePromptTarget(target agent.ExecutionTarget, a agent.Agent, prompt string, timeout time.Duration, executionDir string, stream bool, stdout, stderr io.Writer) (promptResult, error) {
+func executePromptTarget(ctx context.Context, target agent.ExecutionTarget, a agent.Agent, prompt string, timeout time.Duration, executionDir string, stream bool, stdout, stderr io.Writer) (promptResult, error) {
 	switch target.Runner {
 	case agent.RunnerOllamaHTTP:
-		return executeOllamaPrompt(a, prompt, timeout)
+		return executeOllamaPrompt(ctx, a, prompt, timeout)
 	case agent.RunnerCodexCLI:
 		return executeCodexPrompt(a, prompt, timeout, executionDir, stream, stdout, stderr)
 	case agent.RunnerClaudeCLI:
@@ -598,7 +598,7 @@ func executePromptTarget(target agent.ExecutionTarget, a agent.Agent, prompt str
 	case agent.RunnerGeminiCLI:
 		return executeGeminiPrompt(a, prompt, timeout, executionDir, stream, stdout, stderr)
 	case agent.RunnerOpenAIHTTP:
-		return executeOpenAIPrompt(a, prompt, timeout)
+		return executeOpenAIPrompt(ctx, a, prompt, timeout)
 	case agent.RunnerBedrockAPI:
 		return promptResult{}, errors.New("bedrock backend execution is not supported yet")
 	default:
@@ -671,7 +671,7 @@ func validateOllamaEndpoint(baseURL string, timeout time.Duration, operationName
 	return nil
 }
 
-func executeOllamaPrompt(a agent.Agent, prompt string, timeout time.Duration) (promptResult, error) {
+func executeOllamaPrompt(ctx context.Context, a agent.Agent, prompt string, timeout time.Duration) (promptResult, error) {
 	if strings.TrimSpace(a.Model) == "" {
 		return promptResult{}, errors.New("ollama agent requires model")
 	}
@@ -688,7 +688,7 @@ func executeOllamaPrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	body, _ := json.Marshal(payload)
 
 	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/generate", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/generate", bytes.NewReader(body))
 	if err != nil {
 		return promptResult{}, err
 	}
@@ -722,7 +722,7 @@ func executeOllamaPrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 	return promptResult{Response: strings.TrimSpace(out.Response), Usage: usage}, nil
 }
 
-func executeOpenAIPrompt(a agent.Agent, prompt string, timeout time.Duration) (promptResult, error) {
+func executeOpenAIPrompt(ctx context.Context, a agent.Agent, prompt string, timeout time.Duration) (promptResult, error) {
 	if strings.TrimSpace(a.Model) == "" {
 		return promptResult{}, errors.New("openai agent requires model")
 	}
@@ -742,7 +742,7 @@ func executeOpenAIPrompt(a agent.Agent, prompt string, timeout time.Duration) (p
 		return promptResult{}, fmt.Errorf("marshalling openai request payload: %w", err)
 	}
 	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return promptResult{}, err
 	}

--- a/cmd/prompt_backend_test.go
+++ b/cmd/prompt_backend_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -214,7 +215,7 @@ func TestExecuteOpenAIPrompt(t *testing.T) {
 	for _, baseURL := range []string{server.URL, server.URL + "/v1"} {
 		baseURL := baseURL
 		t.Run("ok:"+baseURL, func(t *testing.T) {
-			result, err := executeOpenAIPrompt(agent.Agent{
+			result, err := executeOpenAIPrompt(context.Background(), agent.Agent{
 				Provider: agent.ProviderOpenAI,
 				Model:    "gpt-5",
 				APIKey:   apiKey,
@@ -263,7 +264,7 @@ func TestExecuteOpenAIPromptReturnsStatusError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := executeOpenAIPrompt(agent.Agent{
+	_, err := executeOpenAIPrompt(context.Background(), agent.Agent{
 		Provider: agent.ProviderOpenAI,
 		Model:    "gpt-5",
 		BaseURL:  server.URL,

--- a/cmd/prompt_test.go
+++ b/cmd/prompt_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"strings"
@@ -329,7 +330,7 @@ func TestResolvePromptAgentAutoRejectsRemoteResolvedTargetForLocalOnly(t *testin
 }
 
 func TestExecutePromptTargetUnsupportedRunnerMentionsRunner(t *testing.T) {
-	_, err := executePromptTarget(agent.ExecutionTarget{Runner: agent.RunnerUnknown}, agent.Agent{Provider: agent.ProviderCustom}, "hello", time.Second, t.TempDir(), false, os.Stdout, os.Stderr)
+	_, err := executePromptTarget(context.Background(), agent.ExecutionTarget{Runner: agent.RunnerUnknown}, agent.Agent{Provider: agent.ProviderCustom}, "hello", time.Second, t.TempDir(), false, os.Stdout, os.Stderr)
 	if err == nil {
 		t.Fatalf("expected unsupported runner error")
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -36,11 +36,27 @@ Endpoints:
   POST /api/v1/route           Choose a target for a prompt, without running it
   POST /api/v1/prompt          Route, execute, and return the text with usage
 
-Agentic CLI runners (claude, codex, gemini) run sessions with filesystem
-access and are refused by /api/v1/prompt unless BOTH
-AGENTVAULT_SERVE_ALLOW_AGENTIC=true and AGENTVAULT_SERVE_WORKSPACE=<dir> are
-set. Enabling the capability and choosing where it may write are one decision,
-so neither is enough on its own.
+SECURITY
+
+/api/v1/route and /api/v1/prompt execute work on this machine, so they carry
+guards the read-only endpoints do not:
+
+  - AGENTVAULT_SERVE_KEY is mandatory for them, including on loopback.
+  - Requests carrying an Origin header are refused: they came from a browser,
+    and a cross-origin form post is a CORS simple request that no preflight
+    would have stopped.
+  - Content-Type must be application/json, which a cross-origin form cannot
+    set.
+
+Agentic CLI runners (claude, codex, gemini) run sessions with filesystem access
+and are refused by /api/v1/prompt unless BOTH AGENTVAULT_SERVE_ALLOW_AGENTIC=true
+and AGENTVAULT_SERVE_WORKSPACE=<dir> are set.
+
+AGENTVAULT_SERVE_WORKSPACE is NOT a sandbox. It sets the working directory; an
+auto-approved agent can still write absolute paths, read ~/.ssh and run any
+command as this user. Enabling agentic runners grants shell access to whoever
+holds the API key. Confinement needs a container or a separate account, which
+this process does not provide.
   GET /api/v1/agents           List agents (API keys never exposed)
   GET /api/v1/agents/{name}    Get agent by name
 
@@ -78,8 +94,12 @@ Example:
 			Handler:           mux,
 			ReadHeaderTimeout: 10 * time.Second,
 			ReadTimeout:       30 * time.Second,
-			WriteTimeout:      30 * time.Second,
-			IdleTimeout:       60 * time.Second,
+			// Longer than maxPromptTimeout, or the server truncates a response
+			// the handler is still allowed to be producing -- which would make
+			// the prompt timeout cap meaningless and look like a provider
+			// failure rather than a server one.
+			WriteTimeout: maxPromptTimeout + 30*time.Second,
+			IdleTimeout:  60 * time.Second,
 		}
 		return server.ListenAndServe()
 	},
@@ -221,6 +241,10 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			return
 		}
 
+		if !requireStrongAuth(w, r, apiKey, writeJSON) {
+			return
+		}
+
 		var req routeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
@@ -285,6 +309,10 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 	mux.HandleFunc("/api/v1/prompt", auth(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+
+		if !requireStrongAuth(w, r, apiKey, writeJSON) {
 			return
 		}
 
@@ -414,6 +442,19 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 
 		// The request's context, so a client that disconnects ends the upstream
 		// call rather than leaving it running unwatched.
+		// Logged before execution, not after. If the process is killed mid-run
+		// -- or the agent kills it -- an after-the-fact log records nothing,
+		// and "what did this server run?" becomes unanswerable. The prompt is
+		// deliberately not logged: it can contain the contents of private
+		// documents, and this line exists to answer what ran, not what was
+		// asked.
+		if !httpSafeRunners[target.Runner] {
+			log.Printf(
+				"AGENTIC EXECUTION agent=%s runner=%s workspace=%s prompt_bytes=%d remote=%s",
+				selected.Name, target.Runner, executionDir, len(req.Prompt), r.RemoteAddr,
+			)
+		}
+
 		result, err := executePromptTarget(r.Context(), target, selected, req.Prompt, timeout, executionDir, false, io.Discard, io.Discard)
 		if err != nil {
 			// Detail to the log, not to the caller. A provider error can carry
@@ -537,6 +578,53 @@ func agenticRunnersAllowed() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_ALLOW_AGENTIC")), "true")
 }
 
+// requireStrongAuth reports whether this request may reach an endpoint that
+// executes anything.
+//
+// Two checks the read-only endpoints do not need.
+//
+// An API key is mandatory here even on loopback. `serve` defaults to loopback
+// and the key is otherwise optional, which means an unconfigured server running
+// agentic runners would execute commands for any local process that can reach
+// the port -- including one running as a different user on a shared machine.
+//
+// And a request carrying an Origin header is refused outright, because it came
+// from a browser. A cross-origin form with enctype="text/plain" is a CORS
+// simple request: no preflight, so CORS never gets a chance to block it, and
+// its body can be crafted as valid JSON. Without this check any page you visit
+// can POST to localhost and run commands on your machine. "It only listens on
+// loopback" is not a defence against the browser you are reading this in.
+func requireStrongAuth(w http.ResponseWriter, r *http.Request, apiKey string, writeJSON func(http.ResponseWriter, int, any)) bool {
+	if apiKey == "" {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": "this endpoint requires AGENTVAULT_SERVE_KEY to be set, including on loopback",
+			"code":  "auth_not_configured",
+		})
+		return false
+	}
+
+	if origin := r.Header.Get("Origin"); origin != "" {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": "browser-originated requests are not accepted by this endpoint",
+			"code":  "origin_rejected",
+		})
+		return false
+	}
+
+	// Belt and braces on the same attack: a simple request cannot set this
+	// header, so requiring it excludes form-based cross-origin posts even if an
+	// Origin header is somehow absent.
+	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(strings.ToLower(strings.TrimSpace(ct)), "application/json") {
+		writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
+			"error": "Content-Type must be application/json",
+			"code":  "unsupported_media_type",
+		})
+		return false
+	}
+
+	return true
+}
+
 // agenticWorkspace is the directory a CLI runner is allowed to work in.
 //
 // Required, not optional, and deliberately not defaulted. An empty executionDir
@@ -544,6 +632,13 @@ func agenticRunnersAllowed() bool {
 // server process happens to have been started from -- for claude that is a
 // session with --permission-mode auto, so "wherever systemd put us" is not an
 // acceptable answer. An operator enabling agentic runners has to say where.
+//
+// It is NOT a sandbox, and must not be described as one. cmd.Dir sets the
+// working directory; an auto-approved agent can still write absolute paths,
+// read ~/.ssh and run arbitrary commands as this user. Actual confinement needs
+// a container, a separate account, or seccomp -- none of which this process
+// does. Treat enabling agentic runners as granting shell access to whoever
+// holds the API key.
 func agenticWorkspace() string {
 	return strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_WORKSPACE"))
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -37,8 +37,10 @@ Endpoints:
   POST /api/v1/prompt          Route, execute, and return the text with usage
 
 Agentic CLI runners (claude, codex, gemini) run sessions with filesystem
-access and are refused by /api/v1/prompt unless AGENTVAULT_SERVE_ALLOW_AGENTIC
-is set to true.
+access and are refused by /api/v1/prompt unless BOTH
+AGENTVAULT_SERVE_ALLOW_AGENTIC=true and AGENTVAULT_SERVE_WORKSPACE=<dir> are
+set. Enabling the capability and choosing where it may write are one decision,
+so neither is enough on its own.
   GET /api/v1/agents           List agents (API keys never exposed)
   GET /api/v1/agents/{name}    Get agent by name
 
@@ -364,31 +366,68 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			return
 		}
 
-		if !httpSafeRunners[target.Runner] && !agenticRunnersAllowed() {
+		executionDir := ""
+		if !httpSafeRunners[target.Runner] {
 			// Refused rather than quietly downgraded to another agent: a caller
 			// asking for a coding agent and silently getting a chat model back
 			// would be a worse surprise than being told no.
-			writeJSON(w, http.StatusForbidden, map[string]any{
-				"error": fmt.Sprintf(
-					"runner %q runs an agentic CLI session with filesystem access and is not "+
-						"exposed over HTTP by default; set AGENTVAULT_SERVE_ALLOW_AGENTIC=true "+
-						"to permit it", target.Runner),
-				"agent":  selected.Name,
-				"runner": string(target.Runner),
-			})
-			return
+			if !agenticRunnersAllowed() {
+				writeJSON(w, http.StatusForbidden, map[string]any{
+					"error": fmt.Sprintf(
+						"runner %q runs an agentic CLI session with filesystem access and is not "+
+							"exposed over HTTP by default; set AGENTVAULT_SERVE_ALLOW_AGENTIC=true "+
+							"to permit it", target.Runner),
+					"agent":  selected.Name,
+					"runner": string(target.Runner),
+				})
+				return
+			}
+
+			executionDir = agenticWorkspace()
+			if executionDir == "" {
+				// Permitting the runner without saying where it may work would
+				// run an agent with filesystem access in whatever directory the
+				// server was started from. Enabling the capability and choosing
+				// its blast radius are one decision, so both are required.
+				writeJSON(w, http.StatusForbidden, map[string]any{
+					"error": "AGENTVAULT_SERVE_ALLOW_AGENTIC is set but " +
+						"AGENTVAULT_SERVE_WORKSPACE is not; a CLI runner would execute in the " +
+						"server's own working directory",
+					"agent":  selected.Name,
+					"runner": string(target.Runner),
+				})
+				return
+			}
 		}
 
+		// Bounded. An unbounded timeout on an authenticated endpoint lets one
+		// caller hold a goroutine and an upstream connection for as long as it
+		// likes -- a slow request is fine, an indefinite one is a way to
+		// exhaust the server with a handful of calls.
 		timeout := time.Duration(req.TimeoutSec) * time.Second
 		if timeout <= 0 {
-			timeout = 120 * time.Second
+			timeout = defaultPromptTimeout
+		}
+		if timeout > maxPromptTimeout {
+			timeout = maxPromptTimeout
 		}
 
-		result, err := executePromptTarget(target, selected, req.Prompt, timeout, "", false, io.Discard, io.Discard)
+		// The request's context, so a client that disconnects ends the upstream
+		// call rather than leaving it running unwatched.
+		result, err := executePromptTarget(r.Context(), target, selected, req.Prompt, timeout, executionDir, false, io.Discard, io.Discard)
 		if err != nil {
-			log.Printf("prompt execution failed for agent %s: %v", selected.Name, err)
+			// Detail to the log, not to the caller. A provider error can carry
+			// endpoint URLs, filesystem paths and occasionally a fragment of a
+			// credential, and none of that is stable enough for a client to
+			// depend on either. The code is what a caller branches on.
+			log.Printf("prompt execution failed for agent %s (runner %s): %v", selected.Name, target.Runner, err)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				writeJSON(w, 499, map[string]string{"error": "client closed the request", "code": "cancelled"})
+				return
+			}
 			writeJSON(w, http.StatusBadGateway, map[string]string{
-				"error": fmt.Sprintf("execution failed: %v", err),
+				"error": "the provider could not be reached or failed to respond",
+				"code":  "execution_failed",
 				"agent": selected.Name,
 			})
 			return
@@ -486,8 +525,27 @@ var httpSafeRunners = map[agent.RunnerKind]bool{
 	agent.RunnerOpenAIHTTP: true,
 }
 
+const (
+	defaultPromptTimeout = 120 * time.Second
+	// A ceiling rather than a suggestion. A caller asking for longer is
+	// silently given this, because failing the request would be worse for a
+	// legitimately slow model and the cap is the point either way.
+	maxPromptTimeout = 10 * time.Minute
+)
+
 func agenticRunnersAllowed() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_ALLOW_AGENTIC")), "true")
+}
+
+// agenticWorkspace is the directory a CLI runner is allowed to work in.
+//
+// Required, not optional, and deliberately not defaulted. An empty executionDir
+// leaves cmd.Dir empty, which means the agent runs in whatever directory the
+// server process happens to have been started from -- for claude that is a
+// session with --permission-mode auto, so "wherever systemd put us" is not an
+// acceptable answer. An operator enabling agentic runners has to say where.
+func agenticWorkspace() string {
+	return strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_WORKSPACE"))
 }
 
 func isLoopbackHost(host string) bool {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -33,6 +34,11 @@ Endpoints:
   GET /health                  Health check
   GET /api/v1/status           Server and vault status
   POST /api/v1/route           Choose a target for a prompt, without running it
+  POST /api/v1/prompt          Route, execute, and return the text with usage
+
+Agentic CLI runners (claude, codex, gemini) run sessions with filesystem
+access and are refused by /api/v1/prompt unless AGENTVAULT_SERVE_ALLOW_AGENTIC
+is set to true.
   GET /api/v1/agents           List agents (API keys never exposed)
   GET /api/v1/agents/{name}    Get agent by name
 
@@ -268,6 +274,146 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 		})
 	}))
 
+	// POST /api/v1/prompt
+	//
+	// Routes and executes, returning the text along with token usage and cost.
+	// The usage is the point as much as the answer: a caller that has to
+	// reconstruct what a call cost will get it wrong, and every service that
+	// shipped its own provider layer got it wrong differently.
+	mux.HandleFunc("/api/v1/prompt", auth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+
+		var req promptRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if strings.TrimSpace(req.Prompt) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "prompt is required"})
+			return
+		}
+
+		agents := v.List()
+		shared := v.SharedConfig()
+
+		var selected agent.Agent
+		var decision router.Decision
+		var routed bool
+
+		if name := strings.TrimSpace(req.Agent); name != "" {
+			found := false
+			for _, a := range agents {
+				if strings.EqualFold(a.Name, name) {
+					selected, found = a, true
+					break
+				}
+			}
+			if !found {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("no agent named %q", name)})
+				return
+			}
+		} else {
+			var err error
+			decision, err = router.RouteContext(r.Context(), router.Request{
+				Prompt:            req.Prompt,
+				Agents:            agents,
+				Shared:            shared,
+				Config:            req.toRouterConfig(),
+				ModelCapabilities: v.ListCapabilities(),
+			})
+			if err != nil {
+				switch {
+				case errors.Is(err, router.ErrEmptyPrompt),
+					errors.Is(err, router.ErrNoCandidates),
+					errors.Is(err, router.ErrPolicyUnsatisfiable):
+					writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
+				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+					writeJSON(w, 499, map[string]string{"error": "client closed the request"})
+				default:
+					log.Printf("routing failed: %v", err)
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "routing failed"})
+				}
+				return
+			}
+			// The decision carries a redacted AgentView by design -- it never
+			// includes credentials, which is what keeps the routing response
+			// safe to return. So the executable agent is looked up by name.
+			found := false
+			for _, a := range agents {
+				if strings.EqualFold(a.Name, decision.Selected.Agent.Name) {
+					selected, found = a, true
+					break
+				}
+			}
+			if !found {
+				log.Printf("router selected unknown agent %q", decision.Selected.Agent.Name)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "routing selected an unknown agent"})
+				return
+			}
+			routed = true
+		}
+
+		target := agent.ResolveExecutionTarget(selected)
+		if !target.Supported {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+				"error": fmt.Sprintf("runner %q is not supported for execution", target.Runner),
+			})
+			return
+		}
+
+		if !httpSafeRunners[target.Runner] && !agenticRunnersAllowed() {
+			// Refused rather than quietly downgraded to another agent: a caller
+			// asking for a coding agent and silently getting a chat model back
+			// would be a worse surprise than being told no.
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"error": fmt.Sprintf(
+					"runner %q runs an agentic CLI session with filesystem access and is not "+
+						"exposed over HTTP by default; set AGENTVAULT_SERVE_ALLOW_AGENTIC=true "+
+						"to permit it", target.Runner),
+				"agent":  selected.Name,
+				"runner": string(target.Runner),
+			})
+			return
+		}
+
+		timeout := time.Duration(req.TimeoutSec) * time.Second
+		if timeout <= 0 {
+			timeout = 120 * time.Second
+		}
+
+		result, err := executePromptTarget(target, selected, req.Prompt, timeout, "", false, io.Discard, io.Discard)
+		if err != nil {
+			log.Printf("prompt execution failed for agent %s: %v", selected.Name, err)
+			writeJSON(w, http.StatusBadGateway, map[string]string{
+				"error": fmt.Sprintf("execution failed: %v", err),
+				"agent": selected.Name,
+			})
+			return
+		}
+
+		cost := agent.ComputeCostUSD(&result.Usage, selected.Provider, selected.Model, shared.Pricing)
+
+		payload := map[string]any{
+			"text":     result.Response,
+			"agent":    selected.Name,
+			"provider": string(selected.Provider),
+			"model":    selected.Model,
+			"runner":   string(target.Runner),
+			"usage":    result.Usage,
+			"cost_usd": cost,
+			"routed":   routed,
+			"local":    target.Local,
+		}
+		if routed {
+			payload["mode"] = decision.Mode
+			payload["reasons"] = decision.Selected.Reasons
+		}
+		writeJSON(w, http.StatusOK, payload)
+	}))
+
 	return mux
 }
 
@@ -313,6 +459,35 @@ func (rr routeRequest) toRouterConfig() agent.RouterConfig {
 		cfg.PreferLocal = true
 	}
 	return cfg
+}
+
+// promptRequest is the POST /api/v1/prompt body.
+type promptRequest struct {
+	routeRequest
+	// Agent names the target directly and skips routing. Useful when the
+	// caller has already routed, or is reproducing a previous decision.
+	Agent      string `json:"agent,omitempty"`
+	TimeoutSec int    `json:"timeout_seconds,omitempty"`
+}
+
+// Runners this endpoint will execute over HTTP without being asked twice.
+//
+// These call a model API and return text. The CLI runners do something
+// categorically different: claude runs with --permission-mode auto, codex with
+// workspace-write, gemini with --approval-mode auto_edit. Those are agentic
+// sessions with filesystem access, so exposing them on a socket turns this into
+// remote code execution -- for anyone holding the API key, and for anyone who
+// obtains it later.
+//
+// That is a decision an operator should make deliberately, not one they inherit
+// by starting a server.
+var httpSafeRunners = map[agent.RunnerKind]bool{
+	agent.RunnerOllamaHTTP: true,
+	agent.RunnerOpenAIHTTP: true,
+}
+
+func agenticRunnersAllowed() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_ALLOW_AGENTIC")), "true")
 }
 
 func isLoopbackHost(host string) bool {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nikolareljin/agentvault/internal/agent"
 	"github.com/nikolareljin/agentvault/internal/router"
@@ -282,7 +283,7 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 				// a client that closed its own connection.
 				writeJSON(w, 499, map[string]string{"error": "client closed the request"})
 			default:
-				log.Printf("routing failed: %v", err)
+				log.Printf("routing failed: %s", sanitizeForLog(err.Error()))
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "routing failed"})
 			}
 			return
@@ -363,7 +364,7 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 					writeJSON(w, 499, map[string]string{"error": "client closed the request"})
 				default:
-					log.Printf("routing failed: %v", err)
+					log.Printf("routing failed: %s", sanitizeForLog(err.Error()))
 					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "routing failed"})
 				}
 				return
@@ -379,7 +380,7 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 				}
 			}
 			if !found {
-				log.Printf("router selected unknown agent %q", decision.Selected.Agent.Name)
+				log.Printf("router selected unknown agent %q", sanitizeForLog(decision.Selected.Agent.Name))
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "routing selected an unknown agent"})
 				return
 			}
@@ -450,8 +451,12 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 		// asked.
 		if !httpSafeRunners[target.Runner] {
 			log.Printf(
-				"AGENTIC EXECUTION agent=%s runner=%s workspace=%s prompt_bytes=%d remote=%s",
-				selected.Name, target.Runner, executionDir, len(req.Prompt), r.RemoteAddr,
+				"AGENTIC EXECUTION agent=%q runner=%q workspace=%q prompt_bytes=%d remote=%q",
+				sanitizeForLog(selected.Name),
+				sanitizeForLog(string(target.Runner)),
+				sanitizeForLog(executionDir),
+				len(req.Prompt),
+				sanitizeForLog(r.RemoteAddr),
 			)
 		}
 
@@ -461,7 +466,12 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			// endpoint URLs, filesystem paths and occasionally a fragment of a
 			// credential, and none of that is stable enough for a client to
 			// depend on either. The code is what a caller branches on.
-			log.Printf("prompt execution failed for agent %s (runner %s): %v", selected.Name, target.Runner, err)
+			log.Printf(
+				"prompt execution failed for agent %q (runner %q): %s",
+				sanitizeForLog(selected.Name),
+				sanitizeForLog(string(target.Runner)),
+				sanitizeForLog(err.Error()),
+			)
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				writeJSON(w, 499, map[string]string{"error": "client closed the request", "code": "cancelled"})
 				return
@@ -576,6 +586,34 @@ const (
 
 func agenticRunnersAllowed() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv("AGENTVAULT_SERVE_ALLOW_AGENTIC")), "true")
+}
+
+// sanitizeForLog strips anything that could forge a log line.
+//
+// This matters most for the audit line, whose whole value is being trustworthy:
+// a value carrying a newline could append a second, fabricated
+// "AGENTIC EXECUTION" record, and an audit trail an attacker can write to is
+// worse than none, because it is believed. Control characters go too -- a
+// terminal reading the log should not be steered by its contents.
+func sanitizeForLog(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteByte(' ')
+		case unicode.IsControl(r):
+			// Dropped rather than replaced: a control character in an agent
+			// name or a path is not information anyone needs in a log.
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if len(out) > 256 {
+		return out[:256] + "…"
+	}
+	return out
 }
 
 // requireStrongAuth reports whether this request may reach an endpoint that

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -653,3 +653,47 @@ func TestAWellFormedRequestStillGetsThrough(t *testing.T) {
 		t.Fatalf("status = %d, want 200 for a well-formed authenticated request", resp.StatusCode)
 	}
 }
+
+func TestLogValuesCannotForgeALine(t *testing.T) {
+	// An audit trail an attacker can write to is worse than none, because it is
+	// believed. A newline in a logged value would append a second, fabricated
+	// AGENTIC EXECUTION record.
+	forged := "innocent\nAGENTIC EXECUTION agent=\"trusted\" runner=\"ollama_http\""
+
+	got := sanitizeForLog(forged)
+
+	if strings.Contains(got, "\n") || strings.Contains(got, "\r") {
+		t.Fatalf("sanitised value still contains a line break: %q", got)
+	}
+}
+
+func TestLogSanitiserDropsControlCharacters(t *testing.T) {
+	// A terminal reading the log should not be steered by its contents.
+	got := sanitizeForLog("name\x1b[31m\x00\x07")
+
+	for _, r := range got {
+		if r < 0x20 && r != ' ' {
+			t.Fatalf("control character survived: %q", got)
+		}
+	}
+}
+
+func TestLogSanitiserBoundsLength(t *testing.T) {
+	// One value should not be able to push everything else off the screen, or
+	// fill a disk.
+	got := sanitizeForLog(strings.Repeat("x", 5000))
+
+	if len([]rune(got)) > 257 {
+		t.Fatalf("sanitised value is %d runes, want it bounded", len([]rune(got)))
+	}
+}
+
+func TestLogSanitiserLeavesOrdinaryValuesAlone(t *testing.T) {
+	// A sanitiser that mangles normal input makes the log harder to read, which
+	// is its own kind of failure.
+	for _, value := range []string{"claude-main", "ollama_http", "/srv/agent-workspace", "127.0.0.1:54321"} {
+		if got := sanitizeForLog(value); got != value {
+			t.Fatalf("sanitizeForLog(%q) = %q, want it unchanged", value, got)
+		}
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -305,3 +305,137 @@ func TestLocalOnlyImpliesPreferLocal(t *testing.T) {
 		t.Fatalf("local_only=true gave LocalOnly=%v PreferLocal=%v, want both true", cfg.LocalOnly, cfg.PreferLocal)
 	}
 }
+
+// --- POST /api/v1/prompt -----------------------------------------------------
+
+func postPrompt(t *testing.T, srv *httptest.Server, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/prompt", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	return resp
+}
+
+func TestPromptRefusesAgenticRunnersByDefault(t *testing.T) {
+	// The important one. claude runs with --permission-mode auto, codex with
+	// workspace-write, gemini with --approval-mode auto_edit. Those are agentic
+	// sessions with filesystem access, so putting them on a socket is remote
+	// code execution for anyone holding the API key -- including anyone who
+	// obtains it later. An operator should choose that deliberately rather than
+	// inherit it by starting a server.
+	v := testServeVault(t) // its only agent is a claude CLI agent
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "")
+	resp := postPrompt(t, srv, `{"prompt":"write a file"}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	// The message has to name the opt-in, or an operator cannot act on it.
+	if msg, _ := body["error"].(string); !strings.Contains(msg, "AGENTVAULT_SERVE_ALLOW_AGENTIC") {
+		t.Fatalf("error does not say how to permit it: %v", body["error"])
+	}
+}
+
+func TestPromptRefusesRatherThanSilentlyPickingAnotherAgent(t *testing.T) {
+	// Downgrading a coding agent to a chat model without saying so would be a
+	// worse surprise than being told no.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	resp := postPrompt(t, srv, `{"prompt":"write a file"}`)
+	defer resp.Body.Close()
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	if body["text"] != nil {
+		t.Fatal("a refused request returned generated text")
+	}
+	if body["agent"] == nil {
+		t.Fatal("the refusal does not say which agent was selected")
+	}
+}
+
+func TestPromptRequiresAPrompt(t *testing.T) {
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	resp := postPrompt(t, srv, `{"prompt":"  "}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestPromptRejectsAnUnknownNamedAgent(t *testing.T) {
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	resp := postPrompt(t, srv, `{"prompt":"hi","agent":"not-a-real-agent"}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestPromptRequiresAuth(t *testing.T) {
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
+	defer srv.Close()
+
+	resp := postPrompt(t, srv, `{"prompt":"hi"}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestPromptRejectsGet(t *testing.T) {
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/prompt")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestHTTPSafeRunnersAreOnlyTheNonAgenticOnes(t *testing.T) {
+	// A new runner must not become HTTP-reachable by default just because it
+	// was added; this is the list an operator is trusting.
+	for _, runner := range []agent.RunnerKind{agent.RunnerClaudeCLI, agent.RunnerCodexCLI, agent.RunnerGeminiCLI} {
+		if httpSafeRunners[runner] {
+			t.Fatalf("runner %q is agentic and must not be HTTP-safe by default", runner)
+		}
+	}
+	if !httpSafeRunners[agent.RunnerOllamaHTTP] || !httpSafeRunners[agent.RunnerOpenAIHTTP] {
+		t.Fatal("the model-API runners should be permitted")
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -156,6 +156,7 @@ func TestRouteRequiresAuthLikeEveryOtherEndpoint(t *testing.T) {
 	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
 	defer srv.Close()
 
+	// Deliberately sends no key.
 	resp := postRoute(t, srv, "", `{"prompt":"hello"}`)
 	defer resp.Body.Close()
 
@@ -182,10 +183,10 @@ func TestRouteRejectsGet(t *testing.T) {
 
 func TestRouteRejectsAnEmptyPrompt(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
-	resp := postRoute(t, srv, "", `{"prompt":"   "}`)
+	resp := postRoute(t, srv, testKey, `{"prompt":"   "}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {
@@ -195,10 +196,10 @@ func TestRouteRejectsAnEmptyPrompt(t *testing.T) {
 
 func TestRouteRejectsMalformedJSON(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
-	resp := postRoute(t, srv, "", `{"prompt":`)
+	resp := postRoute(t, srv, testKey, `{"prompt":`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {
@@ -208,10 +209,10 @@ func TestRouteRejectsMalformedJSON(t *testing.T) {
 
 func TestRouteReturnsADecisionWithItsCandidates(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
-	resp := postRoute(t, srv, "", `{"prompt":"refactor this function","allow_fallbacks":true}`)
+	resp := postRoute(t, srv, testKey, `{"prompt":"refactor this function","allow_fallbacks":true}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -241,10 +242,10 @@ func TestRouteDoesNotLeakApiKeys(t *testing.T) {
 	// endpoint that serialises agents has to be equally careful, and it is
 	// easy for that to regress unnoticed.
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
-	resp := postRoute(t, srv, "", `{"prompt":"anything"}`)
+	resp := postRoute(t, srv, testKey, `{"prompt":"anything"}`)
 	defer resp.Body.Close()
 
 	// Assert success first. Without this the test passes when routing starts
@@ -270,11 +271,11 @@ func TestRouteDoesNotLeakApiKeys(t *testing.T) {
 func TestUnsatisfiableConstraintsAre422(t *testing.T) {
 	// The caller asked for something no agent can do. That is their answer.
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	// The only agent is a remote provider, and local_only excludes it.
-	resp := postRoute(t, srv, "", `{"prompt":"review this","local_only":true}`)
+	resp := postRoute(t, srv, testKey, `{"prompt":"review this","local_only":true}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusUnprocessableEntity {
@@ -287,11 +288,11 @@ func TestAMisconfiguredRouterIs500Not422(t *testing.T) {
 	// as 422 would tell the caller they got their input wrong and send whoever
 	// is debugging it looking in the wrong place.
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	t.Setenv("AGENTVAULT_LANGGRAPH_ROUTER_CMD", "")
-	resp := postRoute(t, srv, "", `{"prompt":"anything","mode":"langgraph"}`)
+	resp := postRoute(t, srv, testKey, `{"prompt":"anything","mode":"langgraph"}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusInternalServerError {
@@ -311,6 +312,11 @@ func TestLocalOnlyImpliesPreferLocal(t *testing.T) {
 
 // --- POST /api/v1/prompt -----------------------------------------------------
 
+// testKey is the key every execute-endpoint test server is configured with.
+// The endpoints now require one even on loopback, so a keyless server is a
+// deliberate case rather than the default.
+const testKey = "secret-key"
+
 func postPrompt(t *testing.T, srv *httptest.Server, body string) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/prompt", strings.NewReader(body))
@@ -318,6 +324,7 @@ func postPrompt(t *testing.T, srv *httptest.Server, body string) *http.Response 
 		t.Fatalf("http.NewRequest() error = %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", testKey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Do() error = %v", err)
@@ -333,7 +340,7 @@ func TestPromptRefusesAgenticRunnersByDefault(t *testing.T) {
 	// obtains it later. An operator should choose that deliberately rather than
 	// inherit it by starting a server.
 	v := testServeVault(t) // its only agent is a claude CLI agent
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	// Cleared explicitly: inherited from the environment this test would pass
@@ -363,7 +370,7 @@ func TestPromptRefusesRatherThanSilentlyPickingAnotherAgent(t *testing.T) {
 	// Downgrading a coding agent to a chat model without saying so would be a
 	// worse surprise than being told no.
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "")
@@ -395,7 +402,7 @@ func TestAgenticWithoutAWorkspaceIsStillRefused(t *testing.T) {
 	// with filesystem access in whatever directory the server was started from
 	// -- for claude, a session with --permission-mode auto.
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "true")
@@ -419,7 +426,7 @@ func TestAgenticWithoutAWorkspaceIsStillRefused(t *testing.T) {
 
 func TestPromptRequiresAPrompt(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	resp := postPrompt(t, srv, `{"prompt":"  "}`)
@@ -432,7 +439,7 @@ func TestPromptRequiresAPrompt(t *testing.T) {
 
 func TestPromptRejectsAnUnknownNamedAgent(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
 	defer srv.Close()
 
 	resp := postPrompt(t, srv, `{"prompt":"hi","agent":"not-a-real-agent"}`)
@@ -445,7 +452,7 @@ func TestPromptRejectsAnUnknownNamedAgent(t *testing.T) {
 
 func TestPromptRequiresAuth(t *testing.T) {
 	v := testServeVault(t)
-	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "a-different-key"))
 	defer srv.Close()
 
 	resp := postPrompt(t, srv, `{"prompt":"hi"}`)
@@ -541,5 +548,108 @@ func TestPromptExecutionIsCancelledWhenTheClientDisconnects(t *testing.T) {
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want it to wrap context.Canceled", err)
+	}
+}
+
+// --- Guards on the endpoints that execute -----------------------------------
+
+func TestExecutingEndpointsRequireAKeyEvenOnLoopback(t *testing.T) {
+	// serve defaults to loopback and the key is otherwise optional, so an
+	// unconfigured server running agentic runners would execute commands for
+	// any local process that can reach the port -- including one running as a
+	// different user on a shared machine.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "")) // no key
+	defer srv.Close()
+
+	for _, path := range []string{"/api/v1/route", "/api/v1/prompt"} {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL+path, strings.NewReader(`{"prompt":"hi"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do() error = %v", err)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want 403 when no key is configured", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestBrowserOriginatedRequestsAreRefused(t *testing.T) {
+	// The attack "it only listens on loopback" does not stop: a cross-origin
+	// form with enctype="text/plain" is a CORS simple request, so no preflight
+	// happens and CORS never gets a chance to block it. Its body can be crafted
+	// as valid JSON. Without this check any page the user visits can POST here
+	// and run commands on their machine.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/prompt", strings.NewReader(`{"prompt":"rm -rf /"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "secret-key")
+	req.Header.Set("Origin", "https://evil.example")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for a browser-originated request", resp.StatusCode)
+	}
+}
+
+func TestFormContentTypesAreRefused(t *testing.T) {
+	// The exact content types a cross-origin form can send without a preflight.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
+	defer srv.Close()
+
+	for _, ct := range []string{
+		"text/plain",
+		"application/x-www-form-urlencoded",
+		"multipart/form-data",
+		"",
+	} {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/prompt", strings.NewReader(`{"prompt":"hi"}`))
+		req.Header.Set("x-api-key", "secret-key")
+		if ct != "" {
+			req.Header.Set("Content-Type", ct)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do() error = %v", err)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnsupportedMediaType {
+			t.Fatalf("Content-Type %q gave status %d, want 415", ct, resp.StatusCode)
+		}
+	}
+}
+
+func TestAWellFormedRequestStillGetsThrough(t *testing.T) {
+	// The guards must not break the legitimate caller they exist to protect.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", "secret-key"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/route", strings.NewReader(`{"prompt":"summarise this"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", "secret-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for a well-formed authenticated request", resp.StatusCode)
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nikolareljin/agentvault/internal/agent"
 	"github.com/nikolareljin/agentvault/internal/vault"
@@ -333,7 +336,12 @@ func TestPromptRefusesAgenticRunnersByDefault(t *testing.T) {
 	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
 	defer srv.Close()
 
+	// Cleared explicitly: inherited from the environment this test would pass
+	// or fail depending on the machine it runs on, which is worse than not
+	// having it.
 	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "")
+	t.Setenv("AGENTVAULT_SERVE_WORKSPACE", "")
+
 	resp := postPrompt(t, srv, `{"prompt":"write a file"}`)
 	defer resp.Body.Close()
 
@@ -358,17 +366,54 @@ func TestPromptRefusesRatherThanSilentlyPickingAnotherAgent(t *testing.T) {
 	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
 	defer srv.Close()
 
+	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "")
+	t.Setenv("AGENTVAULT_SERVE_WORKSPACE", "")
+
 	resp := postPrompt(t, srv, `{"prompt":"write a file"}`)
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+
 	var body map[string]any
-	json.NewDecoder(resp.Body).Decode(&body)
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
 
 	if body["text"] != nil {
 		t.Fatal("a refused request returned generated text")
 	}
 	if body["agent"] == nil {
 		t.Fatal("the refusal does not say which agent was selected")
+	}
+}
+
+func TestAgenticWithoutAWorkspaceIsStillRefused(t *testing.T) {
+	// Enabling the capability and choosing its blast radius are one decision.
+	// Permitting the runner without saying where it may work would run an agent
+	// with filesystem access in whatever directory the server was started from
+	// -- for claude, a session with --permission-mode auto.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", ""))
+	defer srv.Close()
+
+	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "true")
+	t.Setenv("AGENTVAULT_SERVE_WORKSPACE", "")
+
+	resp := postPrompt(t, srv, `{"prompt":"write a file"}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if msg, _ := body["error"].(string); !strings.Contains(msg, "AGENTVAULT_SERVE_WORKSPACE") {
+		t.Fatalf("the refusal does not name the missing setting: %v", body["error"])
 	}
 }
 
@@ -437,5 +482,64 @@ func TestHTTPSafeRunnersAreOnlyTheNonAgenticOnes(t *testing.T) {
 	}
 	if !httpSafeRunners[agent.RunnerOllamaHTTP] || !httpSafeRunners[agent.RunnerOpenAIHTTP] {
 		t.Fatal("the model-API runners should be permitted")
+	}
+}
+
+func TestPromptTimeoutIsCapped(t *testing.T) {
+	// Unbounded, an authenticated caller can hold a goroutine and an upstream
+	// connection for as long as it likes -- a slow request is fine, an
+	// indefinite one is a way to exhaust the server with a handful of calls.
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{"unset falls back to the default", 0, defaultPromptTimeout},
+		{"negative falls back to the default", -5, defaultPromptTimeout},
+		{"a reasonable value is honoured", 30, 30 * time.Second},
+		{"a day is capped", 86400, maxPromptTimeout},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := time.Duration(tc.seconds) * time.Second
+			if got <= 0 {
+				got = defaultPromptTimeout
+			}
+			if got > maxPromptTimeout {
+				got = maxPromptTimeout
+			}
+			if got != tc.want {
+				t.Fatalf("timeout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPromptExecutionIsCancelledWhenTheClientDisconnects(t *testing.T) {
+	// An already-cancelled context, rather than racing a blocking server: the
+	// property under test is that the context reaches the request at all. If it
+	// does not, the call ignores cancellation and runs to its own timeout,
+	// which is the bug -- the model keeps generating for a caller that is no
+	// longer listening and the server pays for it.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the request reached the server despite a cancelled context")
+	}))
+	defer upstream.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := executeOllamaPrompt(ctx, agent.Agent{
+		Provider: agent.ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  upstream.URL,
+	}, "hello", 30*time.Second)
+
+	if err == nil {
+		t.Fatal("execution succeeded with a cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want it to wrap context.Canceled", err)
 	}
 }


### PR DESCRIPTION
Closes #45. The execution half: routes, runs, and returns the text with token usage and cost.

The usage matters as much as the answer — a caller that has to reconstruct what a call cost will get it wrong, and every service that shipped its own provider layer got it wrong differently.

## ⚠️ The security decision is the substance of this PR

Three of the runners **do not** call a model API and return text. They start agentic CLI sessions with filesystem access:

| runner | how it runs |
|---|---|
| `claude_cli` | `--permission-mode auto` |
| `codex_cli` | workspace-write |
| `gemini_cli` | `--approval-mode auto_edit` |

Putting those on a socket is **remote code execution on the host** — available to anyone holding the API key, including anyone who obtains it later.

So only the model-API runners (`ollama_http`, `openai_http`) are HTTP-reachable by default:

```
403  runner "claude_cli" runs an agentic CLI session with filesystem access and is
     not exposed over HTTP by default; set AGENTVAULT_SERVE_ALLOW_AGENTIC=true to
     permit it
```

An operator sets that **deliberately**, rather than inheriting it by starting a server. A test asserts the allowlist contains only the non-agentic runners, so a runner added later doesn't become reachable simply by existing.

## Refused, not silently downgraded

A caller asking for a coding agent and quietly getting a chat model back would be a worse surprise than being told no. The response names the agent and runner so the refusal is actionable.

## Credentials never travel through the routing decision

The decision carries a **redacted** `AgentView` with no API key — that's what makes the routing response safe to return. So it can't be executed directly, and the executable agent is looked up by name afterwards. Reaching for it explicitly is the honest way to say that.

## Shape

```json
{"prompt": "summarise this", "prefer_local": true}
```
```json
{"text": "...", "agent": "local", "provider": "ollama", "model": "llama3.2",
 "runner": "ollama_http", "usage": {...}, "cost_usd": 0, "routed": true,
 "local": true, "mode": "heuristic", "reasons": [...]}
```

`{"agent": "name"}` skips routing — for a caller that has already routed, or is reproducing a previous decision.

## Verification

```
go build ./...   clean      go vet ./...   clean
gofmt -l         clean      go test ./...  all packages pass
```

Seven tests, including that the default refusal names the opt-in (an error an operator can't act on is not much of an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)